### PR TITLE
Fix navigation links

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,12 +28,8 @@
       <ul class="navbar-menu">
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html" class="current">About</a></li>
-        <li><a href="types-of-law.html">Types of Law</a></li>
-        <li><a href="alabama-courts.html">Courts in Alabama</a></li>
-        <li><a href="practice-areas.html">Areas of Practice in AL</a></li>
-        <li><a href="blog.html">Attorney's Blog</a></li>
-        <li><a href="links.html">Links</a></li>
-        <li><a href="references.html">References</a></li>
+        <li><a href="resources/blog.html">Blog</a></li>
+        <li><a href="resources/faq.html">FAQ</a></li>
         <li><a href="contact.html" class="btn">Contact</a></li>
       </ul>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -27,12 +27,8 @@
       <ul class="navbar-menu">
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
-        <li><a href="types-of-law.html">Types of Law</a></li>
-        <li><a href="alabama-courts.html">Courts in Alabama</a></li>
-        <li><a href="practice-areas.html">Areas of Practice in AL</a></li>
-        <li><a href="blog.html">Attorney's Blog</a></li>
-        <li><a href="links.html">Links</a></li>
-        <li><a href="references.html">References</a></li>
+        <li><a href="resources/blog.html">Blog</a></li>
+        <li><a href="resources/faq.html">FAQ</a></li>
         <li><a href="contact.html" class="btn current">Contact</a></li>
       </ul>
     </div>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Disclaimer - Gabriel Smith Attorney</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header class="header">
+    <div class="navbar container">
+      <a href="index.html" class="navbar-brand">Gabriel Smith Attorney at Law</a>
+      <button class="menu-toggle" aria-label="Open navigation">&#9776;</button>
+      <ul class="navbar-menu">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="resources/blog.html">Blog</a></li>
+        <li><a href="resources/faq.html">FAQ</a></li>
+        <li><a href="contact.html" class="btn">Contact</a></li>
+      </ul>
+    </div>
+  </header>
+
+  <main class="container">
+    <h1>Website Disclaimer</h1>
+    <p>This website provides general information only and does not constitute legal advice. Viewing or interacting with this site does not create an attorney‑client relationship. You should consult a qualified attorney for advice regarding your individual situation.</p>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2025 Law Office of Gabriel Smith. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <script src="js/menu.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -42,12 +42,9 @@
       <button class="menu-toggle" aria-label="Open navigation">&#9776;</button>
       <ul class="navbar-menu">
         <li><a href="index.html" class="current">Home</a></li>
-        <li><a href="types-of-law.html">Types of Law</a></li>
-        <li><a href="alabama-courts.html">Courts in Alabama</a></li>
-        <li><a href="practice-areas.html">Areas of Practice in AL</a></li>
-        <li><a href="blog.html">Attorney's Blog</a></li>
-        <li><a href="links.html">Links</a></li>
-        <li><a href="references.html">References</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="resources/blog.html">Blog</a></li>
+        <li><a href="resources/faq.html">FAQ</a></li>
         <li><a href="contact.html" class="btn">Contact</a></li>
       </ul>
     </div>
@@ -77,22 +74,22 @@
           <article class="card">
             <h3>Criminal Defense</h3>
             <p>From misdemeanors to felony charges, Gabriel provides aggressive representation aimed at safeguarding your rights.</p>
-            <p><a href="criminal-defense.html">Learn more</a></p>
+            <p><a href="practice-areas/criminal-law/criminal-defense.html">Learn more</a></p>
           </article>
           <article class="card">
             <h3>Personal Injury</h3>
             <p>Dedicated to securing fair compensation for victims of negligence, including car accidents and workplace injuries.</p>
-            <p><a href="personal-injury.html">Learn more</a></p>
+            <p><a href="practice-areas/labor-employment/workers-compensation-law.html">Learn more</a></p>
           </article>
           <article class="card">
             <h3>Family Law</h3>
             <p>Compassionate counsel for divorce, child custody, and other domestic matters, focused on the best outcomes for your family.</p>
-            <p><a href="family-law.html">Learn more</a></p>
+            <p><a href="practice-areas/family-estate/family-law.html">Learn more</a></p>
           </article>
           <article class="card">
             <h3>Estate Planning</h3>
             <p>Guiding you through wills, trusts, and probate to protect your assets and loved ones.</p>
-            <p><a href="estate-planning.html">Learn more</a></p>
+            <p><a href="practice-areas/family-estate/estate-planning.html">Learn more</a></p>
           </article>
         </div>
       </div>
@@ -113,15 +110,15 @@
       <div class="container">
         <h2>From the Blog</h2>
         <article>
-          <h3><a href="blog/post1.html">Understanding Alabama's Criminal Process</a></h3>
+          <h3><a href="resources/blog.html">Understanding Alabama's Criminal Process</a></h3>
           <p>An overview of key steps when facing charges, from arrest to trial.</p>
         </article>
         <article>
-          <h3><a href="blog/post2.html">Protecting Your Rights After a Car Accident</a></h3>
+          <h3><a href="resources/blog.html">Protecting Your Rights After a Car Accident</a></h3>
           <p>Important actions to take immediately after a collision to maximize your recovery.</p>
         </article>
         <article>
-          <h3><a href="blog/post3.html">Planning Your Estate: Wills vs. Trusts</a></h3>
+          <h3><a href="resources/blog.html">Planning Your Estate: Wills vs. Trusts</a></h3>
           <p>The advantages of each approach and how to choose the right plan for your family.</p>
         </article>
       </div>


### PR DESCRIPTION
## Summary
- simplify header navigation on index, about, and contact pages
- link practice area cards and blog preview to existing pages
- add missing disclaimer page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687460982c8c8321884ee48daf19b708