### PR TITLE
Add personal injury page and expand criminal law pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,9 +155,9 @@
         Dedicated to securing fair compensation for victims of negligence, including car accidents and workplace injuries.
        </p>
        <p>
-        <a href="practice-areas/labor-employment/workers-compensation-law.html">
-         Learn more
-        </a>
+       <a href="practice-areas/civil-litigation/personal-injury.html">
+        Learn more
+       </a>
        </p>
       </article>
       <article class="card">

--- a/practice-areas/civil-litigation/personal-injury.html
+++ b/practice-areas/civil-litigation/personal-injury.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+  <meta charset="utf-8"/>
+  <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
+  <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <title>
+   Personal Injury Attorney | Gabriel Law Firm
+  </title>
+  <link href="https://gabrielsmithattorney.com/practice-areas/civil-litigation/personal-injury.html" rel="canonical"/>
+  <meta content="Representation for victims of negligence including car accidents, slip and fall injuries, and other personal injury claims." name="description"/>
+  <meta content="Law Office of Gabriel Smith LLC" name="author"/>
+  <meta content="index, follow" name="robots"/>
+  <meta content="en_US" property="og:locale"/>
+  <meta content="website" property="og:type"/>
+  <meta content="Gabriel Law Firm" property="og:site_name"/>
+  <meta content="Personal Injury Attorney | Gabriel Law Firm" property="og:title"/>
+  <meta content="Representation for victims of negligence including car accidents, slip and fall injuries, and other personal injury claims." property="og:description"/>
+  <meta content="https://gabrielsmithattorney.com/practice-areas/civil-litigation/personal-injury.html" property="og:url"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" property="og:image"/>
+  <meta content="summary_large_image" name="twitter:card"/>
+  <meta content="Personal Injury Attorney | Gabriel Law Firm" name="twitter:title"/>
+  <meta content="Representation for victims of negligence including car accidents, slip and fall injuries, and other personal injury claims." name="twitter:description"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" name="twitter:image"/>
+  <meta content="personal injury lawyer, car accident attorney, Alabama" name="keywords"/>
+  <link href="/favicon.ico" rel="icon"/>
+  <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com" rel="preconnect"/>
+  <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+ </head>
+ <body>
+  <header>
+   <div class="navbar container">
+    <a class="navbar-brand" href="/index.html">
+     Gabriel Smith Attorney at Law
+    </a>
+    <button aria-label="Open navigation" class="menu-toggle">
+     ☰
+    </button>
+    <ul class="navbar-menu">
+     <li>
+      <a href="/index.html">
+       <i aria-hidden="true" class="fa-solid fa-house">
+       </i>
+       Home
+      </a>
+     </li>
+     <li>
+      <a class="current" href="/practice-areas/index.html">
+       <i aria-hidden="true" class="fa-solid fa-scale-balanced">
+       </i>
+       Practice Areas
+      </a>
+     </li>
+     <li>
+      <a href="/about.html">
+       <i aria-hidden="true" class="fa-solid fa-user">
+       </i>
+       About
+      </a>
+     </li>
+     <li>
+      <a href="/resources/blog.html">
+       <i aria-hidden="true" class="fa-solid fa-newspaper">
+       </i>
+       Blog
+      </a>
+     </li>
+     <li>
+      <a href="/resources/faq.html">
+       <i aria-hidden="true" class="fa-solid fa-circle-question">
+       </i>
+       FAQ
+      </a>
+     </li>
+     <li>
+      <a class="btn" href="/contact.html">
+       <i aria-hidden="true" class="fa-solid fa-phone">
+       </i>
+       Contact
+      </a>
+     </li>
+    </ul>
+   </div>
+  </header>
+  <section class="hero">
+   <div class="container">
+    <h1>
+     Personal Injury
+    </h1>
+    <p class="drop-cap">
+     If you have been hurt because someone else acted carelessly, you may be entitled to compensation. I handle a range of personal injury matters from car crashes to slip and fall incidents.
+    </p>
+   </div>
+  </section>
+  <section class="alt">
+   <div class="container">
+    <p>
+     Motor vehicle accidents often result in mounting medical bills and time away from work. We gather police reports, medical records, and witness statements to build a strong claim for damages.
+    </p>
+    <p>
+     Premises liability cases involve hazards like wet floors or unsafe stairs. Property owners have a duty to keep their premises reasonably safe. When they fail, injured visitors deserve fair recovery.
+    </p>
+    <p>
+     I work directly with clients to evaluate insurance coverage and negotiate with adjusters. When settlement is not possible, I am prepared to file suit and advocate for your rights in court.
+    </p>
+    <p>
+     Call <a href="tel:+13347501729">(334) 750-1729</a> or email <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> to discuss your injury claim.
+    </p>
+   </div>
+  </section>
+  <footer class="footer">
+   <div class="container">
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-phone">
+     </i>
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
+     or
+     <i aria-hidden="true" class="fa-solid fa-envelope">
+     </i>
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">
+      Gabrielthecryptolawyer@gmail.com
+     </a>
+    </p>
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-map-marker-alt">
+     </i>
+     Downtown Opelika, AL
+    </p>
+    <p>
+     <a href="https://www.facebook.com/GabrielSmithAttorney/">
+      Facebook
+     </a>
+    </p>
+    <p>
+     © 2025 Law Office of Gabriel Smith. All rights reserved.
+    </p>
+    <p>
+     <a href="../../disclaimer.html">
+      Disclaimer
+     </a>
+    </p>
+   </div>
+  </footer>
+  <script src="../../js/menu.js">
+  </script>
+ </body>
+</html>

--- a/practice-areas/criminal-law/hate-crime-law.html
+++ b/practice-areas/criminal-law/hate-crime-law.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+  <meta charset="utf-8"/>
+  <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
+  <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <title>
+   Hate Crime Defense Attorney | Gabriel Law Firm
+  </title>
+  <link href="https://gabrielsmithattorney.com/practice-areas/criminal-law/hate-crime-law.html" rel="canonical"/>
+  <meta content="Defense counsel for individuals accused of hate crimes or bias-motivated offenses." name="description"/>
+  <meta content="Law Office of Gabriel Smith LLC" name="author"/>
+  <meta content="index, follow" name="robots"/>
+  <meta content="en_US" property="og:locale"/>
+  <meta content="website" property="og:type"/>
+  <meta content="Gabriel Law Firm" property="og:site_name"/>
+  <meta content="Hate Crime Defense Attorney | Gabriel Law Firm" property="og:title"/>
+  <meta content="Defense counsel for individuals accused of hate crimes or bias-motivated offenses." property="og:description"/>
+  <meta content="https://gabrielsmithattorney.com/practice-areas/criminal-law/hate-crime-law.html" property="og:url"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" property="og:image"/>
+  <meta content="summary_large_image" name="twitter:card"/>
+  <meta content="Hate Crime Defense Attorney | Gabriel Law Firm" name="twitter:title"/>
+  <meta content="Defense counsel for individuals accused of hate crimes or bias-motivated offenses." name="twitter:description"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" name="twitter:image"/>
+  <meta content="hate crime defense lawyer, criminal attorney, Alabama" name="keywords"/>
+  <link href="/favicon.ico" rel="icon"/>
+  <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com" rel="preconnect"/>
+  <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+ </head>
+ <body>
+  <header>
+   <div class="navbar container">
+    <a class="navbar-brand" href="/index.html">Gabriel Smith Attorney at Law</a>
+    <button aria-label="Open navigation" class="menu-toggle">☰</button>
+    <ul class="navbar-menu">
+     <li>
+      <a href="/index.html"><i aria-hidden="true" class="fa-solid fa-house"></i>Home</a>
+     </li>
+     <li>
+      <a class="current" href="/practice-areas/index.html"><i aria-hidden="true" class="fa-solid fa-scale-balanced"></i>Practice Areas</a>
+     </li>
+     <li>
+      <a href="/about.html"><i aria-hidden="true" class="fa-solid fa-user"></i>About</a>
+     </li>
+     <li>
+      <a href="/resources/blog.html"><i aria-hidden="true" class="fa-solid fa-newspaper"></i>Blog</a>
+     </li>
+     <li>
+      <a href="/resources/faq.html"><i aria-hidden="true" class="fa-solid fa-circle-question"></i>FAQ</a>
+     </li>
+     <li>
+      <a class="btn" href="/contact.html"><i aria-hidden="true" class="fa-solid fa-phone"></i>Contact</a>
+     </li>
+    </ul>
+   </div>
+  </header>
+  <section class="hero">
+   <div class="container">
+    <h1>Hate Crime Defense</h1>
+    <p class="drop-cap">
+     Allegations of bias-motivated conduct can carry severe penalties and social stigma. We provide a vigorous defense while ensuring constitutional protections are fully respected.
+    </p>
+   </div>
+  </section>
+  <section class="alt">
+   <div class="container">
+    <p>
+     Hate crime charges often involve enhanced sentencing and heightened public scrutiny. Our firm carefully examines the evidence, from witness statements to digital communications, to challenge the prosecution's narrative.
+    </p>
+    <p>
+     The law requires proof that bias or prejudice motivated the alleged offense. We analyze the circumstances to determine whether the state can meet this high burden and advocate for reduction or dismissal where appropriate.
+    </p>
+    <p>
+     For discreet representation, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+    </p>
+   </div>
+  </section>
+  <footer class="footer">
+   <div class="container">
+    <p><i aria-hidden="true" class="fa-solid fa-phone"></i><a href="tel:+13347501729">(334) 750-1729</a> or <i aria-hidden="true" class="fa-solid fa-envelope"></i><a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a></p>
+    <p><i aria-hidden="true" class="fa-solid fa-map-marker-alt"></i>Downtown Opelika, AL</p>
+    <p><a href="https://www.facebook.com/GabrielSmithAttorney/">Facebook</a></p>
+    <p>© 2025 Law Office of Gabriel Smith. All rights reserved.</p>
+    <p><a href="../../disclaimer.html">Disclaimer</a></p>
+   </div>
+  </footer>
+  <script src="../../js/menu.js"></script>
+ </body>
+</html>

--- a/practice-areas/criminal-law/juvenile-law.html
+++ b/practice-areas/criminal-law/juvenile-law.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+  <meta charset="utf-8"/>
+  <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
+  <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <title>
+   Juvenile Law Attorney | Gabriel Law Firm
+  </title>
+  <link href="https://gabrielsmithattorney.com/practice-areas/criminal-law/juvenile-law.html" rel="canonical"/>
+  <meta content="Advocacy for minors facing delinquency petitions and related juvenile court matters." name="description"/>
+  <meta content="Law Office of Gabriel Smith LLC" name="author"/>
+  <meta content="index, follow" name="robots"/>
+  <meta content="en_US" property="og:locale"/>
+  <meta content="website" property="og:type"/>
+  <meta content="Gabriel Law Firm" property="og:site_name"/>
+  <meta content="Juvenile Law Attorney | Gabriel Law Firm" property="og:title"/>
+  <meta content="Advocacy for minors facing delinquency petitions and related juvenile court matters." property="og:description"/>
+  <meta content="https://gabrielsmithattorney.com/practice-areas/criminal-law/juvenile-law.html" property="og:url"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" property="og:image"/>
+  <meta content="summary_large_image" name="twitter:card"/>
+  <meta content="Juvenile Law Attorney | Gabriel Law Firm" name="twitter:title"/>
+  <meta content="Advocacy for minors facing delinquency petitions and related juvenile court matters." name="twitter:description"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" name="twitter:image"/>
+  <meta content="juvenile defense lawyer, delinquency, Alabama" name="keywords"/>
+  <link href="/favicon.ico" rel="icon"/>
+  <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com" rel="preconnect"/>
+  <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+ </head>
+ <body>
+  <header>
+   <div class="navbar container">
+    <a class="navbar-brand" href="/index.html">
+     Gabriel Smith Attorney at Law
+    </a>
+    <button aria-label="Open navigation" class="menu-toggle">
+     ☰
+    </button>
+    <ul class="navbar-menu">
+     <li>
+      <a href="/index.html">
+       <i aria-hidden="true" class="fa-solid fa-house"></i>
+       Home
+      </a>
+     </li>
+     <li>
+      <a class="current" href="/practice-areas/index.html">
+       <i aria-hidden="true" class="fa-solid fa-scale-balanced"></i>
+       Practice Areas
+      </a>
+     </li>
+     <li>
+      <a href="/about.html">
+       <i aria-hidden="true" class="fa-solid fa-user"></i>
+       About
+      </a>
+     </li>
+     <li>
+      <a href="/resources/blog.html">
+       <i aria-hidden="true" class="fa-solid fa-newspaper"></i>
+       Blog
+      </a>
+     </li>
+     <li>
+      <a href="/resources/faq.html">
+       <i aria-hidden="true" class="fa-solid fa-circle-question"></i>
+       FAQ
+      </a>
+     </li>
+     <li>
+      <a class="btn" href="/contact.html">
+       <i aria-hidden="true" class="fa-solid fa-phone"></i>
+       Contact
+      </a>
+     </li>
+    </ul>
+   </div>
+  </header>
+  <section class="hero">
+   <div class="container">
+    <h1>Juvenile Law</h1>
+    <p class="drop-cap">
+     Juvenile proceedings require a careful balance between accountability and the opportunity for rehabilitation. Our firm stands with young clients and their families during every step of the process.
+    </p>
+   </div>
+  </section>
+  <section class="alt">
+   <div class="container">
+    <p>
+     Alabama's juvenile courts handle offenses differently from the adult system. We work to protect minors from severe penalties while ensuring they receive the guidance and resources needed to move forward.
+    </p>
+    <p>
+     Early intervention is critical. We review police reports, school records, and other documents to craft a defense tailored to each child's circumstances. Our goal is to minimize lasting consequences that can affect educational and career prospects.
+    </p>
+    <p>
+     If your child is facing a delinquency petition, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> for dedicated representation.
+    </p>
+   </div>
+  </section>
+  <footer class="footer">
+   <div class="container">
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-phone"></i>
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or
+     <i aria-hidden="true" class="fa-solid fa-envelope"></i>
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a>
+    </p>
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-map-marker-alt"></i>
+     Downtown Opelika, AL
+    </p>
+    <p>
+     <a href="https://www.facebook.com/GabrielSmithAttorney/">Facebook</a>
+    </p>
+    <p>© 2025 Law Office of Gabriel Smith. All rights reserved.</p>
+    <p>
+     <a href="../../disclaimer.html">Disclaimer</a>
+    </p>
+   </div>
+  </footer>
+  <script src="../../js/menu.js"></script>
+ </body>
+</html>

--- a/practice-areas/criminal-law/white-collar-criminal-defense.html
+++ b/practice-areas/criminal-law/white-collar-criminal-defense.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+  <meta charset="utf-8"/>
+  <meta content="IE=edge" http-equiv="X-UA-Compatible"/>
+  <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <title>
+   White Collar Criminal Defense | Gabriel Law Firm
+  </title>
+  <link href="https://gabrielsmithattorney.com/practice-areas/criminal-law/white-collar-criminal-defense.html" rel="canonical"/>
+  <meta content="Defense representation in fraud, embezzlement, and other white collar crime investigations." name="description"/>
+  <meta content="Law Office of Gabriel Smith LLC" name="author"/>
+  <meta content="index, follow" name="robots"/>
+  <meta content="en_US" property="og:locale"/>
+  <meta content="website" property="og:type"/>
+  <meta content="Gabriel Law Firm" property="og:site_name"/>
+  <meta content="White Collar Criminal Defense | Gabriel Law Firm" property="og:title"/>
+  <meta content="Defense representation in fraud, embezzlement, and other white collar crime investigations." property="og:description"/>
+  <meta content="https://gabrielsmithattorney.com/practice-areas/criminal-law/white-collar-criminal-defense.html" property="og:url"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" property="og:image"/>
+  <meta content="summary_large_image" name="twitter:card"/>
+  <meta content="White Collar Criminal Defense | Gabriel Law Firm" name="twitter:title"/>
+  <meta content="Defense representation in fraud, embezzlement, and other white collar crime investigations." name="twitter:description"/>
+  <meta content="https://gabrielsmithattorney.com/images/og-image.jpg" name="twitter:image"/>
+  <meta content="white collar crime defense lawyer, fraud, Alabama" name="keywords"/>
+  <link href="/favicon.ico" rel="icon"/>
+  <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
+  <link href="/site.webmanifest" rel="manifest"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com" rel="preconnect"/>
+  <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+ </head>
+ <body>
+  <header>
+   <div class="navbar container">
+    <a class="navbar-brand" href="/index.html">Gabriel Smith Attorney at Law</a>
+    <button aria-label="Open navigation" class="menu-toggle">☰</button>
+    <ul class="navbar-menu">
+     <li><a href="/index.html"><i aria-hidden="true" class="fa-solid fa-house"></i>Home</a></li>
+     <li><a class="current" href="/practice-areas/index.html"><i aria-hidden="true" class="fa-solid fa-scale-balanced"></i>Practice Areas</a></li>
+     <li><a href="/about.html"><i aria-hidden="true" class="fa-solid fa-user"></i>About</a></li>
+     <li><a href="/resources/blog.html"><i aria-hidden="true" class="fa-solid fa-newspaper"></i>Blog</a></li>
+     <li><a href="/resources/faq.html"><i aria-hidden="true" class="fa-solid fa-circle-question"></i>FAQ</a></li>
+     <li><a class="btn" href="/contact.html"><i aria-hidden="true" class="fa-solid fa-phone"></i>Contact</a></li>
+    </ul>
+   </div>
+  </header>
+  <section class="hero">
+   <div class="container">
+    <h1>White Collar Criminal Defense</h1>
+    <p class="drop-cap">
+     Financial crime investigations are document-heavy and complex. We provide experienced guidance to protect your rights during audits, grand jury proceedings, and trial.
+    </p>
+   </div>
+  </section>
+  <section class="alt">
+   <div class="container">
+    <p>
+     Agencies often devote significant resources to allegations of fraud and embezzlement. We scrutinize financial records and work with forensic experts when necessary to challenge the prosecution's theories.
+    </p>
+    <p>
+     Negotiating with federal and state authorities requires tact and discretion. Our approach focuses on mitigating exposure and pursuing resolutions that minimize collateral consequences for businesses and professionals alike.
+    </p>
+    <p>
+     For counsel regarding white collar investigations, call <a href="tel:+13347501729">(334) 750-1729</a> or email <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+    </p>
+   </div>
+  </section>
+  <footer class="footer">
+   <div class="container">
+    <p><i aria-hidden="true" class="fa-solid fa-phone"></i><a href="tel:+13347501729">(334) 750-1729</a> or <i aria-hidden="true" class="fa-solid fa-envelope"></i><a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a></p>
+    <p><i aria-hidden="true" class="fa-solid fa-map-marker-alt"></i>Downtown Opelika, AL</p>
+    <p><a href="https://www.facebook.com/GabrielSmithAttorney/">Facebook</a></p>
+    <p>© 2025 Law Office of Gabriel Smith. All rights reserved.</p>
+    <p><a href="../../disclaimer.html">Disclaimer</a></p>
+   </div>
+  </footer>
+  <script src="../../js/menu.js"></script>
+ </body>
+</html>

--- a/practice-areas/index.html
+++ b/practice-areas/index.html
@@ -108,6 +108,11 @@
       </a>
      </li>
      <li>
+      <a href="civil-litigation/personal-injury.html">
+       Personal Injury
+      </a>
+     </li>
+     <li>
       <a href="civil-litigation/mass-tort-law.html">
        Mass Tort Law
       </a>


### PR DESCRIPTION
## Summary
- create Personal Injury practice area page with detailed content
- add the new page to the practice areas index
- update home page link for Personal Injury card
- flesh out Juvenile Law, Hate Crime Law, and White Collar Criminal Defense pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874b0816b0c8321acdb5a7a80b61af3