### PR TITLE
Fix contact email on criminal law pages

### DIFF
--- a/practice-areas/criminal-law/hate-crime-law.html
+++ b/practice-areas/criminal-law/hate-crime-law.html
@@ -76,7 +76,7 @@
      The law requires proof that bias or prejudice motivated the alleged offense. We analyze the circumstances to determine whether the state can meet this high burden and advocate for reduction or dismissal where appropriate.
     </p>
     <p>
-     For discreet representation, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+     For discreet representation, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a>.
     </p>
    </div>
   </section>

--- a/practice-areas/criminal-law/juvenile-law.html
+++ b/practice-areas/criminal-law/juvenile-law.html
@@ -98,7 +98,7 @@
      Early intervention is critical. We review police reports, school records, and other documents to craft a defense tailored to each child's circumstances. Our goal is to minimize lasting consequences that can affect educational and career prospects.
     </p>
     <p>
-     If your child is facing a delinquency petition, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> for dedicated representation.
+     If your child is facing a delinquency petition, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a> for dedicated representation.
     </p>
    </div>
   </section>

--- a/practice-areas/criminal-law/white-collar-criminal-defense.html
+++ b/practice-areas/criminal-law/white-collar-criminal-defense.html
@@ -64,7 +64,7 @@
      Negotiating with federal and state authorities requires tact and discretion. Our approach focuses on mitigating exposure and pursuing resolutions that minimize collateral consequences for businesses and professionals alike.
     </p>
     <p>
-     For counsel regarding white collar investigations, call <a href="tel:+13347501729">(334) 750-1729</a> or email <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+     For counsel regarding white collar investigations, call <a href="tel:+13347501729">(334) 750-1729</a> or email <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a>.
     </p>
    </div>
   </section>


### PR DESCRIPTION
## Summary
- standardize the email address in three criminal-law pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874b883a21c83219aa32d1a127b667a