### PR TITLE
Add contact CTAs to corporate pages

### DIFF
--- a/practice-areas/corporate-business/corporate-law.html
+++ b/practice-areas/corporate-business/corporate-law.html
@@ -119,6 +119,13 @@
     <p>
      Whether guiding a start-up or an established enterprise, we provide strategic advice that supports growth and guards against disputes. Each solution is tailored to your objectives and the unique challenges of your industry.
     </p>
+    <p>
+     For guidance on corporate governance or transactions, call (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     for more information.
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/corporate-business/mergers-acquisitions-law.html
+++ b/practice-areas/corporate-business/mergers-acquisitions-law.html
@@ -119,6 +119,13 @@
     <p>
      From negotiation to final integration, our firm manages the details so your organization can focus on growth. We work to deliver transactions that advance your business while minimizing disruption.
     </p>
+    <p>
+     If you need skilled counsel for a merger or acquisition, call (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     .
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/corporate-business/venture-capital-law.html
+++ b/practice-areas/corporate-business/venture-capital-law.html
@@ -119,6 +119,13 @@
     <p>
      With sound legal advice, emerging companies can raise capital without sacrificing control. We work to forge durable relationships between investors and founders, positioning businesses for sustainable growth.
     </p>
+    <p>
+     To discuss your fundraising goals, call (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     .
+    </p>
    </div>
   </section>
   <footer class="footer">


### PR DESCRIPTION
## Summary
- encourage readers to reach out for help by including call-to-action paragraphs on each corporate business page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874b99199d08321b2b89712c01e2a37