### PR TITLE
Add CSS links to real estate pages

### DIFF
--- a/practice-areas/real-estate-construction/construction-law.html
+++ b/practice-areas/real-estate-construction/construction-law.html
@@ -25,6 +25,7 @@
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>

--- a/practice-areas/real-estate-construction/landlord-tenant-law.html
+++ b/practice-areas/real-estate-construction/landlord-tenant-law.html
@@ -25,6 +25,7 @@
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>

--- a/practice-areas/real-estate-construction/real-estate-law.html
+++ b/practice-areas/real-estate-construction/real-estate-law.html
@@ -25,6 +25,7 @@
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>


### PR DESCRIPTION
## Summary
- fix missing stylesheet links on three real estate construction pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874bbf7d5d4832197c608e3bd68ca60