### PR TITLE
Improve practice pages accessibility

### DIFF
--- a/practice-areas/dispute-resolution/alternative-dispute-resolution.html
+++ b/practice-areas/dispute-resolution/alternative-dispute-resolution.html
@@ -41,6 +41,7 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -95,7 +96,8 @@
     </ul>
    </div>
   </header>
-  <section class="hero">
+  <main id="main-content">
+   <section class="hero">
    <div class="container">
     <h1>
      Alternative Dispute Resolution
@@ -105,7 +107,7 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+   <section class="alt">
    <div class="container">
     <p>
      ADR allows parties to select neutral decision-makers who can focus on their unique issues. This tailored approach often yields faster outcomes than traditional litigation.
@@ -114,14 +116,15 @@
      Preparation remains critical even outside the courtroom. We gather evidence, evaluate legal positions, and present persuasive arguments to maximize the likelihood of a favorable result.
     </p>
     <p>
-     If you seek efficient alternatives to litigation, reach out at (334) 750-1729 or email
+     If you seek efficient alternatives to litigation, reach out at <a href="tel:+13347501729">(334) 750-1729</a> or email
      <a href="mailto:gabrieljoseph.smith@gmail.com">
       gabrieljoseph.smith@gmail.com
      </a>
      to discuss the best method for your dispute.
     </p>
    </div>
-  </section>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/dispute-resolution/arbitration-law.html
+++ b/practice-areas/dispute-resolution/arbitration-law.html
@@ -41,6 +41,7 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -95,7 +96,8 @@
     </ul>
    </div>
   </header>
-  <section class="hero">
+  <main id="main-content">
+   <section class="hero">
    <div class="container">
     <h1>
      Arbitration
@@ -105,7 +107,7 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+   <section class="alt">
    <div class="container">
     <p>
      Effective arbitration begins with a well-drafted clause. We advise businesses on language that preserves key rights while ensuring enforceability under federal and state law.
@@ -114,14 +116,15 @@
      Once a claim arises, we guide clients through selection of arbitrators, discovery, and evidentiary hearings. Our approach balances efficiency with thorough advocacy.
     </p>
     <p>
-     Final awards are binding and may be confirmed by a court. For counsel on arbitration agreements or proceedings, call (334) 750-1729 or email
+     Final awards are binding and may be confirmed by a court. For counsel on arbitration agreements or proceedings, call <a href="tel:+13347501729">(334) 750-1729</a> or email
      <a href="mailto:gabrieljoseph.smith@gmail.com">
       gabrieljoseph.smith@gmail.com
      </a>
      .
     </p>
    </div>
-  </section>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/dispute-resolution/mediation-law.html
+++ b/practice-areas/dispute-resolution/mediation-law.html
@@ -41,6 +41,7 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -95,7 +96,8 @@
     </ul>
    </div>
   </header>
-  <section class="hero">
+  <main id="main-content">
+   <section class="hero">
    <div class="container">
     <h1>
      Mediation
@@ -105,7 +107,7 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+   <section class="alt">
    <div class="container">
     <p>
      The mediator guides the discussion but does not impose a decision. This process empowers participants to maintain control while exploring creative settlement options.
@@ -114,14 +116,15 @@
      Confidentiality encourages open communication, allowing parties to address underlying concerns without fear of public exposure. Agreements reached in mediation can often be incorporated into court orders.
     </p>
     <p>
-     If you believe mediation could resolve your dispute effectively, call (334) 750-1729 or email
+     If you believe mediation could resolve your dispute effectively, call <a href="tel:+13347501729">(334) 750-1729</a> or email
      <a href="mailto:gabrieljoseph.smith@gmail.com">
       gabrieljoseph.smith@gmail.com
      </a>
      for more information.
     </p>
    </div>
-  </section>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/environment-energy/cannabis-law.html
+++ b/practice-areas/environment-energy/cannabis-law.html
@@ -41,6 +41,7 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -95,7 +96,8 @@
     </ul>
    </div>
   </header>
-  <section class="hero">
+  <main id="main-content">
+   <section class="hero">
    <div class="container">
     <h1>
      Cannabis Law
@@ -105,7 +107,7 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+   <section class="alt">
    <div class="container">
     <p>
      State permits govern cultivation, processing, transport, and sale of medical cannabis. We assist with applications, background checks, and regulatory filings to establish compliance from the outset.
@@ -114,14 +116,15 @@
      Because federal law still classifies marijuana as a controlled substance, careful attention must be paid to banking and taxation. Our guidance helps minimize risk while respecting both state and federal constraints.
     </p>
     <p>
-     Ongoing compliance reviews safeguard licenses and maintain good standing with regulators. To discuss your cannabis business plans, call (334) 750-1729 or email
+     Ongoing compliance reviews safeguard licenses and maintain good standing with regulators. To discuss your cannabis business plans, call <a href="tel:+13347501729">(334) 750-1729</a> or email
      <a href="mailto:gabrieljoseph.smith@gmail.com">
       gabrieljoseph.smith@gmail.com
      </a>
      .
     </p>
    </div>
-  </section>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/environment-energy/energy-law.html
+++ b/practice-areas/environment-energy/energy-law.html
@@ -41,6 +41,7 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -95,7 +96,8 @@
     </ul>
    </div>
   </header>
-  <section class="hero">
+  <main id="main-content">
+   <section class="hero">
    <div class="container">
     <h1>
      Energy Law
@@ -105,7 +107,7 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+   <section class="alt">
    <div class="container">
     <p>
      Energy projects often require navigating federal and state approvals. We assist clients with permitting, environmental review, and utility regulations, ensuring each venture proceeds within applicable legal frameworks.
@@ -114,14 +116,15 @@
      Contracts play a central role in energy development. Whether drafting supply agreements or negotiating rights-of-way, we strive to protect the interests of landowners, operators, and investors throughout each stage of a project.
     </p>
     <p>
-     Regulatory compliance extends beyond initial licensing. We monitor changes in legislation and policy, advising on reporting obligations and best practices. For guidance on your energy matters, call (334) 750-1729 or email
+     Regulatory compliance extends beyond initial licensing. We monitor changes in legislation and policy, advising on reporting obligations and best practices. For guidance on your energy matters, call <a href="tel:+13347501729">(334) 750-1729</a> or email
      <a href="mailto:gabrieljoseph.smith@gmail.com">
       gabrieljoseph.smith@gmail.com
      </a>
      .
     </p>
    </div>
-  </section>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/environment-energy/oil-gas-law.html
+++ b/practice-areas/environment-energy/oil-gas-law.html
@@ -41,6 +41,7 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -95,7 +96,8 @@
     </ul>
    </div>
   </header>
-  <section class="hero">
+  <main id="main-content">
+   <section class="hero">
    <div class="container">
     <h1>
      Oil &amp; Gas Law
@@ -105,7 +107,7 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+   <section class="alt">
    <div class="container">
     <p>
      Leasing arrangements define the relationship between property owners and operators. We prepare and review these contracts to secure fair compensation and clear responsibility for development.
@@ -114,14 +116,15 @@
      Royalties and production payments require careful accounting. Our firm ensures compliance with reporting standards and addresses disputes over deductions or allocation of proceeds.
     </p>
     <p>
-     Regulatory agencies monitor drilling, pipeline construction, and site remediation. For counsel on your oil and gas ventures, call (334) 750-1729 or email
+     Regulatory agencies monitor drilling, pipeline construction, and site remediation. For counsel on your oil and gas ventures, call <a href="tel:+13347501729">(334) 750-1729</a> or email
      <a href="mailto:gabrieljoseph.smith@gmail.com">
       gabrieljoseph.smith@gmail.com
      </a>
      .
     </p>
    </div>
-  </section>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/environment-energy/renewable-energy-law.html
+++ b/practice-areas/environment-energy/renewable-energy-law.html
@@ -41,6 +41,7 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -95,7 +96,8 @@
     </ul>
    </div>
   </header>
-  <section class="hero">
+  <main id="main-content">
+   <section class="hero">
    <div class="container">
     <h1>
      Renewable Energy Law
@@ -105,7 +107,7 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+   <section class="alt">
    <div class="container">
     <p>
      Renewable installations require careful attention to zoning, interconnection standards, and environmental review. We address these issues early so your project can proceed without unnecessary delay.
@@ -114,14 +116,15 @@
      State and federal incentives can offset significant development costs. Our firm advises on available grants, tax credits, and power purchase agreements that support profitable clean energy ventures.
     </p>
     <p>
-     As regulations evolve, compliance remains key to maintaining operations. For help navigating permits and contracts in the renewable sector, call (334) 750-1729 or email
+     As regulations evolve, compliance remains key to maintaining operations. For help navigating permits and contracts in the renewable sector, call <a href="tel:+13347501729">(334) 750-1729</a> or email
      <a href="mailto:gabrieljoseph.smith@gmail.com">
       gabrieljoseph.smith@gmail.com
      </a>
      .
     </p>
    </div>
-  </section>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>


### PR DESCRIPTION
## Summary
- add skip links and `<main>` markup to environmental and dispute pages
- convert phone references into clickable `tel:` links for easier calling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874bc8019308321b8db5357afac9e96