### PR TITLE
Add fonts before CSS on practice pages

### DIFF
--- a/practice-areas/civil-litigation/appellate-law.html
+++ b/practice-areas/civil-litigation/appellate-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -160,7 +160,7 @@
     </p>
    </div>
   </footer>
-  <script defer src="../../js/menu.js">
+  <script defer="" src="../../js/menu.js">
   </script>
  </body>
 </html>

--- a/practice-areas/civil-litigation/civil-litigation.html
+++ b/practice-areas/civil-litigation/civil-litigation.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -164,7 +164,7 @@
     </p>
    </div>
   </footer>
-  <script defer src="../../js/menu.js">
+  <script defer="" src="../../js/menu.js">
   </script>
  </body>
 </html>

--- a/practice-areas/civil-litigation/class-actions.html
+++ b/practice-areas/civil-litigation/class-actions.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -164,7 +164,7 @@
     </p>
    </div>
   </footer>
-  <script defer src="../../js/menu.js">
+  <script defer="" src="../../js/menu.js">
   </script>
  </body>
 </html>

--- a/practice-areas/civil-litigation/mass-tort-law.html
+++ b/practice-areas/civil-litigation/mass-tort-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -164,7 +164,7 @@
     </p>
    </div>
   </footer>
-  <script defer src="../../js/menu.js">
+  <script defer="" src="../../js/menu.js">
   </script>
  </body>
 </html>

--- a/practice-areas/civil-litigation/personal-injury.html
+++ b/practice-areas/civil-litigation/personal-injury.html
@@ -26,11 +26,11 @@
   <link href="/favicon.ico" rel="icon"/>
   <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
   <link href="/site.webmanifest" rel="manifest"/>
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -109,7 +109,15 @@
      I work directly with clients to evaluate insurance coverage and negotiate with adjusters. When settlement is not possible, I am prepared to file suit and advocate for your rights in court.
     </p>
     <p>
-     Call <a href="tel:+13347501729">(334) 750-1729</a> or email <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> to discuss your injury claim.
+     Call
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     to discuss your injury claim.
     </p>
    </div>
   </section>

--- a/practice-areas/corporate-business/corporate-law.html
+++ b/practice-areas/corporate-business/corporate-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main">Skip to main content</a>
+  <a class="skip-link" href="#main">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -97,45 +99,49 @@
    </div>
   </header>
   <main id="main">
-  <section class="hero" id="hero">
-   <div class="container">
-    <h1>
-     Corporate Law
-    </h1>
-    <p class="drop-cap">
-     Our firm advises businesses on formation, governance, and compliance so they can grow with confidence.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Corporations operate within a complex regulatory framework. At the formation stage, we help clients choose suitable entity structures and complete required filings. Careful documentation at the outset builds a solid legal foundation.
-    </p>
-    <p>
-     Once a company is organized, directors and officers must observe formalities that preserve limited liability. We counsel leadership on fiduciary duties, meeting protocols, and recordkeeping. Sound governance reassures investors and reduces risk.
-    </p>
-    <p>
-     Operational matters often demand precise contracts. We prepare bylaws, shareholder agreements, vendor arrangements, and employment policies while monitoring both state and federal regulations to keep your business compliant.
-    </p>
-    <p>
-     Whether guiding a start-up or an established enterprise, we provide strategic advice that supports growth and guards against disputes. Each solution is tailored to your objectives and the unique challenges of your industry.
-    </p>
-    <p>
-     For guidance on corporate governance or transactions, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     for more information.
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
- </main>
+   <section class="hero" id="hero">
+    <div class="container">
+     <h1>
+      Corporate Law
+     </h1>
+     <p class="drop-cap">
+      Our firm advises businesses on formation, governance, and compliance so they can grow with confidence.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Corporations operate within a complex regulatory framework. At the formation stage, we help clients choose suitable entity structures and complete required filings. Careful documentation at the outset builds a solid legal foundation.
+     </p>
+     <p>
+      Once a company is organized, directors and officers must observe formalities that preserve limited liability. We counsel leadership on fiduciary duties, meeting protocols, and recordkeeping. Sound governance reassures investors and reduces risk.
+     </p>
+     <p>
+      Operational matters often demand precise contracts. We prepare bylaws, shareholder agreements, vendor arrangements, and employment policies while monitoring both state and federal regulations to keep your business compliant.
+     </p>
+     <p>
+      Whether guiding a start-up or an established enterprise, we provide strategic advice that supports growth and guards against disputes. Each solution is tailored to your objectives and the unique challenges of your industry.
+     </p>
+     <p>
+      For guidance on corporate governance or transactions, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      for more information.
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/corporate-business/franchise-law.html
+++ b/practice-areas/corporate-business/franchise-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main">Skip to main content</a>
+  <a class="skip-link" href="#main">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -97,38 +99,42 @@
    </div>
   </header>
   <main id="main">
-  <section class="hero" id="hero">
-   <div class="container">
-    <h1>
-     Franchise Law
-    </h1>
-    <p class="drop-cap">
-     We help businesses expand through franchising while ensuring compliance with federal and state regulations.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Franchising enables growth by licensing a proven business model. We prepare franchise disclosure documents and register them where required, providing transparency for potential franchisees.
-    </p>
-    <p>
-     A well-crafted franchise agreement sets expectations for trademark use, territory protection, fees, and operational standards. Our office customizes these agreements so franchisors and franchisees understand their respective obligations.
-    </p>
-    <p>
-     Ongoing compliance is vital. We advise on licensing, employment, and advertising rules so each location operates within the law while maintaining consistent quality.
-    </p>
-    <p>
-     Whether establishing a new franchise system or buying an existing unit, we offer practical guidance on renewals and dispute resolution, helping protect the brand and investment over time.
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
- </main>
+   <section class="hero" id="hero">
+    <div class="container">
+     <h1>
+      Franchise Law
+     </h1>
+     <p class="drop-cap">
+      We help businesses expand through franchising while ensuring compliance with federal and state regulations.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Franchising enables growth by licensing a proven business model. We prepare franchise disclosure documents and register them where required, providing transparency for potential franchisees.
+     </p>
+     <p>
+      A well-crafted franchise agreement sets expectations for trademark use, territory protection, fees, and operational standards. Our office customizes these agreements so franchisors and franchisees understand their respective obligations.
+     </p>
+     <p>
+      Ongoing compliance is vital. We advise on licensing, employment, and advertising rules so each location operates within the law while maintaining consistent quality.
+     </p>
+     <p>
+      Whether establishing a new franchise system or buying an existing unit, we offer practical guidance on renewals and dispute resolution, helping protect the brand and investment over time.
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/corporate-business/mergers-acquisitions-law.html
+++ b/practice-areas/corporate-business/mergers-acquisitions-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main">Skip to main content</a>
+  <a class="skip-link" href="#main">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -97,45 +99,49 @@
    </div>
   </header>
   <main id="main">
-  <section class="hero" id="hero">
-   <div class="container">
-    <h1>
-     Mergers &amp; Acquisitions
-    </h1>
-    <p class="drop-cap">
-     We navigate complex transactions so that businesses can merge or acquire with clarity and confidence.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Mergers and acquisitions require careful preparation. We begin with thorough due diligence to uncover financial obligations, regulatory concerns, and potential liabilities. This insight guides negotiations and helps structure a sound deal.
-    </p>
-    <p>
-     When drafting definitive agreements, we safeguard our clients' interests through precise representations, warranties, and indemnities. We address federal and state requirements so each transaction satisfies legal standards and meets strategic objectives.
-    </p>
-    <p>
-     Some industries demand government approval before closing. We coordinate regulatory filings and shareholder communications to keep the process on schedule and minimize post-closing exposure.
-    </p>
-    <p>
-     From negotiation to final integration, our firm manages the details so your organization can focus on growth. We work to deliver transactions that advance your business while minimizing disruption.
-    </p>
-    <p>
-     If you need skilled counsel for a merger or acquisition, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
- </main>
+   <section class="hero" id="hero">
+    <div class="container">
+     <h1>
+      Mergers &amp; Acquisitions
+     </h1>
+     <p class="drop-cap">
+      We navigate complex transactions so that businesses can merge or acquire with clarity and confidence.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Mergers and acquisitions require careful preparation. We begin with thorough due diligence to uncover financial obligations, regulatory concerns, and potential liabilities. This insight guides negotiations and helps structure a sound deal.
+     </p>
+     <p>
+      When drafting definitive agreements, we safeguard our clients' interests through precise representations, warranties, and indemnities. We address federal and state requirements so each transaction satisfies legal standards and meets strategic objectives.
+     </p>
+     <p>
+      Some industries demand government approval before closing. We coordinate regulatory filings and shareholder communications to keep the process on schedule and minimize post-closing exposure.
+     </p>
+     <p>
+      From negotiation to final integration, our firm manages the details so your organization can focus on growth. We work to deliver transactions that advance your business while minimizing disruption.
+     </p>
+     <p>
+      If you need skilled counsel for a merger or acquisition, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/corporate-business/venture-capital-law.html
+++ b/practice-areas/corporate-business/venture-capital-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main">Skip to main content</a>
+  <a class="skip-link" href="#main">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -97,45 +99,49 @@
    </div>
   </header>
   <main id="main">
-  <section class="hero" id="hero">
-   <div class="container">
-    <h1>
-     Venture Capital Law
-    </h1>
-    <p class="drop-cap">
-     We counsel entrepreneurs and investors through financing rounds while maintaining compliance with securities laws.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Securing venture capital involves more than attracting investors. We assist startups in drafting clear business plans and preparing accurate disclosures so they can present opportunities effectively and legally.
-    </p>
-    <p>
-     Investment agreements dictate governance and economic rights. Our office drafts terms for preferred shares, board composition, and liquidation preferences, balancing investors' demands with founders' long-term vision.
-    </p>
-    <p>
-     Ongoing regulatory obligations cannot be ignored once funding is secured. We help maintain cap tables, craft policies, and satisfy reporting requirements that instill confidence in future investors and regulators alike.
-    </p>
-    <p>
-     With sound legal advice, emerging companies can raise capital without sacrificing control. We work to forge durable relationships between investors and founders, positioning businesses for sustainable growth.
-    </p>
-    <p>
-     To discuss your fundraising goals, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
- </main>
+   <section class="hero" id="hero">
+    <div class="container">
+     <h1>
+      Venture Capital Law
+     </h1>
+     <p class="drop-cap">
+      We counsel entrepreneurs and investors through financing rounds while maintaining compliance with securities laws.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Securing venture capital involves more than attracting investors. We assist startups in drafting clear business plans and preparing accurate disclosures so they can present opportunities effectively and legally.
+     </p>
+     <p>
+      Investment agreements dictate governance and economic rights. Our office drafts terms for preferred shares, board composition, and liquidation preferences, balancing investors' demands with founders' long-term vision.
+     </p>
+     <p>
+      Ongoing regulatory obligations cannot be ignored once funding is secured. We help maintain cap tables, craft policies, and satisfy reporting requirements that instill confidence in future investors and regulators alike.
+     </p>
+     <p>
+      With sound legal advice, emerging companies can raise capital without sacrificing control. We work to forge durable relationships between investors and founders, positioning businesses for sustainable growth.
+     </p>
+     <p>
+      To discuss your fundraising goals, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/criminal-law/criminal-defense.html
+++ b/practice-areas/criminal-law/criminal-defense.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>

--- a/practice-areas/criminal-law/hate-crime-law.html
+++ b/practice-areas/criminal-law/hate-crime-law.html
@@ -26,42 +26,72 @@
   <link href="/favicon.ico" rel="icon"/>
   <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
   <link href="/site.webmanifest" rel="manifest"/>
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
    <div class="navbar container">
-    <a class="navbar-brand" href="/index.html">Gabriel Smith Attorney at Law</a>
-    <button aria-label="Open navigation" class="menu-toggle">☰</button>
+    <a class="navbar-brand" href="/index.html">
+     Gabriel Smith Attorney at Law
+    </a>
+    <button aria-label="Open navigation" class="menu-toggle">
+     ☰
+    </button>
     <ul class="navbar-menu">
      <li>
-      <a href="/index.html"><i aria-hidden="true" class="fa-solid fa-house"></i>Home</a>
+      <a href="/index.html">
+       <i aria-hidden="true" class="fa-solid fa-house">
+       </i>
+       Home
+      </a>
      </li>
      <li>
-      <a class="current" href="/practice-areas/index.html"><i aria-hidden="true" class="fa-solid fa-scale-balanced"></i>Practice Areas</a>
+      <a class="current" href="/practice-areas/index.html">
+       <i aria-hidden="true" class="fa-solid fa-scale-balanced">
+       </i>
+       Practice Areas
+      </a>
      </li>
      <li>
-      <a href="/about.html"><i aria-hidden="true" class="fa-solid fa-user"></i>About</a>
+      <a href="/about.html">
+       <i aria-hidden="true" class="fa-solid fa-user">
+       </i>
+       About
+      </a>
      </li>
      <li>
-      <a href="/resources/blog.html"><i aria-hidden="true" class="fa-solid fa-newspaper"></i>Blog</a>
+      <a href="/resources/blog.html">
+       <i aria-hidden="true" class="fa-solid fa-newspaper">
+       </i>
+       Blog
+      </a>
      </li>
      <li>
-      <a href="/resources/faq.html"><i aria-hidden="true" class="fa-solid fa-circle-question"></i>FAQ</a>
+      <a href="/resources/faq.html">
+       <i aria-hidden="true" class="fa-solid fa-circle-question">
+       </i>
+       FAQ
+      </a>
      </li>
      <li>
-      <a class="btn" href="/contact.html"><i aria-hidden="true" class="fa-solid fa-phone"></i>Contact</a>
+      <a class="btn" href="/contact.html">
+       <i aria-hidden="true" class="fa-solid fa-phone">
+       </i>
+       Contact
+      </a>
      </li>
     </ul>
    </div>
   </header>
   <section class="hero">
    <div class="container">
-    <h1>Hate Crime Defense</h1>
+    <h1>
+     Hate Crime Defense
+    </h1>
     <p class="drop-cap">
      Allegations of bias-motivated conduct can carry severe penalties and social stigma. We provide a vigorous defense while ensuring constitutional protections are fully respected.
     </p>
@@ -76,19 +106,54 @@
      The law requires proof that bias or prejudice motivated the alleged offense. We analyze the circumstances to determine whether the state can meet this high burden and advocate for reduction or dismissal where appropriate.
     </p>
     <p>
-     For discreet representation, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a>.
+     For discreet representation, contact us at
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
+     or
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">
+      Gabrielthecryptolawyer@gmail.com
+     </a>
+     .
     </p>
    </div>
   </section>
   <footer class="footer">
    <div class="container">
-    <p><i aria-hidden="true" class="fa-solid fa-phone"></i><a href="tel:+13347501729">(334) 750-1729</a> or <i aria-hidden="true" class="fa-solid fa-envelope"></i><a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a></p>
-    <p><i aria-hidden="true" class="fa-solid fa-map-marker-alt"></i>Downtown Opelika, AL</p>
-    <p><a href="https://www.facebook.com/GabrielSmithAttorney/">Facebook</a></p>
-    <p>© 2025 Law Office of Gabriel Smith. All rights reserved.</p>
-    <p><a href="../../disclaimer.html">Disclaimer</a></p>
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-phone">
+     </i>
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
+     or
+     <i aria-hidden="true" class="fa-solid fa-envelope">
+     </i>
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">
+      Gabrielthecryptolawyer@gmail.com
+     </a>
+    </p>
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-map-marker-alt">
+     </i>
+     Downtown Opelika, AL
+    </p>
+    <p>
+     <a href="https://www.facebook.com/GabrielSmithAttorney/">
+      Facebook
+     </a>
+    </p>
+    <p>
+     © 2025 Law Office of Gabriel Smith. All rights reserved.
+    </p>
+    <p>
+     <a href="../../disclaimer.html">
+      Disclaimer
+     </a>
+    </p>
    </div>
   </footer>
-  <script src="../../js/menu.js"></script>
+  <script src="../../js/menu.js">
+  </script>
  </body>
 </html>

--- a/practice-areas/criminal-law/juvenile-law.html
+++ b/practice-areas/criminal-law/juvenile-law.html
@@ -26,11 +26,11 @@
   <link href="/favicon.ico" rel="icon"/>
   <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
   <link href="/site.webmanifest" rel="manifest"/>
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -44,37 +44,43 @@
     <ul class="navbar-menu">
      <li>
       <a href="/index.html">
-       <i aria-hidden="true" class="fa-solid fa-house"></i>
+       <i aria-hidden="true" class="fa-solid fa-house">
+       </i>
        Home
       </a>
      </li>
      <li>
       <a class="current" href="/practice-areas/index.html">
-       <i aria-hidden="true" class="fa-solid fa-scale-balanced"></i>
+       <i aria-hidden="true" class="fa-solid fa-scale-balanced">
+       </i>
        Practice Areas
       </a>
      </li>
      <li>
       <a href="/about.html">
-       <i aria-hidden="true" class="fa-solid fa-user"></i>
+       <i aria-hidden="true" class="fa-solid fa-user">
+       </i>
        About
       </a>
      </li>
      <li>
       <a href="/resources/blog.html">
-       <i aria-hidden="true" class="fa-solid fa-newspaper"></i>
+       <i aria-hidden="true" class="fa-solid fa-newspaper">
+       </i>
        Blog
       </a>
      </li>
      <li>
       <a href="/resources/faq.html">
-       <i aria-hidden="true" class="fa-solid fa-circle-question"></i>
+       <i aria-hidden="true" class="fa-solid fa-circle-question">
+       </i>
        FAQ
       </a>
      </li>
      <li>
       <a class="btn" href="/contact.html">
-       <i aria-hidden="true" class="fa-solid fa-phone"></i>
+       <i aria-hidden="true" class="fa-solid fa-phone">
+       </i>
        Contact
       </a>
      </li>
@@ -83,7 +89,9 @@
   </header>
   <section class="hero">
    <div class="container">
-    <h1>Juvenile Law</h1>
+    <h1>
+     Juvenile Law
+    </h1>
     <p class="drop-cap">
      Juvenile proceedings require a careful balance between accountability and the opportunity for rehabilitation. Our firm stands with young clients and their families during every step of the process.
     </p>
@@ -98,32 +106,54 @@
      Early intervention is critical. We review police reports, school records, and other documents to craft a defense tailored to each child's circumstances. Our goal is to minimize lasting consequences that can affect educational and career prospects.
     </p>
     <p>
-     If your child is facing a delinquency petition, contact us at <a href="tel:+13347501729">(334) 750-1729</a> or <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a> for dedicated representation.
+     If your child is facing a delinquency petition, contact us at
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
+     or
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">
+      Gabrielthecryptolawyer@gmail.com
+     </a>
+     for dedicated representation.
     </p>
    </div>
   </section>
   <footer class="footer">
    <div class="container">
     <p>
-     <i aria-hidden="true" class="fa-solid fa-phone"></i>
-     <a href="tel:+13347501729">(334) 750-1729</a>
+     <i aria-hidden="true" class="fa-solid fa-phone">
+     </i>
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
      or
-     <i aria-hidden="true" class="fa-solid fa-envelope"></i>
-     <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a>
+     <i aria-hidden="true" class="fa-solid fa-envelope">
+     </i>
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">
+      Gabrielthecryptolawyer@gmail.com
+     </a>
     </p>
     <p>
-     <i aria-hidden="true" class="fa-solid fa-map-marker-alt"></i>
+     <i aria-hidden="true" class="fa-solid fa-map-marker-alt">
+     </i>
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/">Facebook</a>
+     <a href="https://www.facebook.com/GabrielSmithAttorney/">
+      Facebook
+     </a>
     </p>
-    <p>© 2025 Law Office of Gabriel Smith. All rights reserved.</p>
     <p>
-     <a href="../../disclaimer.html">Disclaimer</a>
+     © 2025 Law Office of Gabriel Smith. All rights reserved.
+    </p>
+    <p>
+     <a href="../../disclaimer.html">
+      Disclaimer
+     </a>
     </p>
    </div>
   </footer>
-  <script src="../../js/menu.js"></script>
+  <script src="../../js/menu.js">
+  </script>
  </body>
 </html>

--- a/practice-areas/criminal-law/white-collar-criminal-defense.html
+++ b/practice-areas/criminal-law/white-collar-criminal-defense.html
@@ -26,30 +26,72 @@
   <link href="/favicon.ico" rel="icon"/>
   <link href="/apple-touch-icon.png" rel="apple-touch-icon"/>
   <link href="/site.webmanifest" rel="manifest"/>
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
-  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
    <div class="navbar container">
-    <a class="navbar-brand" href="/index.html">Gabriel Smith Attorney at Law</a>
-    <button aria-label="Open navigation" class="menu-toggle">☰</button>
+    <a class="navbar-brand" href="/index.html">
+     Gabriel Smith Attorney at Law
+    </a>
+    <button aria-label="Open navigation" class="menu-toggle">
+     ☰
+    </button>
     <ul class="navbar-menu">
-     <li><a href="/index.html"><i aria-hidden="true" class="fa-solid fa-house"></i>Home</a></li>
-     <li><a class="current" href="/practice-areas/index.html"><i aria-hidden="true" class="fa-solid fa-scale-balanced"></i>Practice Areas</a></li>
-     <li><a href="/about.html"><i aria-hidden="true" class="fa-solid fa-user"></i>About</a></li>
-     <li><a href="/resources/blog.html"><i aria-hidden="true" class="fa-solid fa-newspaper"></i>Blog</a></li>
-     <li><a href="/resources/faq.html"><i aria-hidden="true" class="fa-solid fa-circle-question"></i>FAQ</a></li>
-     <li><a class="btn" href="/contact.html"><i aria-hidden="true" class="fa-solid fa-phone"></i>Contact</a></li>
+     <li>
+      <a href="/index.html">
+       <i aria-hidden="true" class="fa-solid fa-house">
+       </i>
+       Home
+      </a>
+     </li>
+     <li>
+      <a class="current" href="/practice-areas/index.html">
+       <i aria-hidden="true" class="fa-solid fa-scale-balanced">
+       </i>
+       Practice Areas
+      </a>
+     </li>
+     <li>
+      <a href="/about.html">
+       <i aria-hidden="true" class="fa-solid fa-user">
+       </i>
+       About
+      </a>
+     </li>
+     <li>
+      <a href="/resources/blog.html">
+       <i aria-hidden="true" class="fa-solid fa-newspaper">
+       </i>
+       Blog
+      </a>
+     </li>
+     <li>
+      <a href="/resources/faq.html">
+       <i aria-hidden="true" class="fa-solid fa-circle-question">
+       </i>
+       FAQ
+      </a>
+     </li>
+     <li>
+      <a class="btn" href="/contact.html">
+       <i aria-hidden="true" class="fa-solid fa-phone">
+       </i>
+       Contact
+      </a>
+     </li>
     </ul>
    </div>
   </header>
   <section class="hero">
    <div class="container">
-    <h1>White Collar Criminal Defense</h1>
+    <h1>
+     White Collar Criminal Defense
+    </h1>
     <p class="drop-cap">
      Financial crime investigations are document-heavy and complex. We provide experienced guidance to protect your rights during audits, grand jury proceedings, and trial.
     </p>
@@ -64,19 +106,54 @@
      Negotiating with federal and state authorities requires tact and discretion. Our approach focuses on mitigating exposure and pursuing resolutions that minimize collateral consequences for businesses and professionals alike.
     </p>
     <p>
-     For counsel regarding white collar investigations, call <a href="tel:+13347501729">(334) 750-1729</a> or email <a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a>.
+     For counsel regarding white collar investigations, call
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
+     or email
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">
+      Gabrielthecryptolawyer@gmail.com
+     </a>
+     .
     </p>
    </div>
   </section>
   <footer class="footer">
    <div class="container">
-    <p><i aria-hidden="true" class="fa-solid fa-phone"></i><a href="tel:+13347501729">(334) 750-1729</a> or <i aria-hidden="true" class="fa-solid fa-envelope"></i><a href="mailto:Gabrielthecryptolawyer@gmail.com">Gabrielthecryptolawyer@gmail.com</a></p>
-    <p><i aria-hidden="true" class="fa-solid fa-map-marker-alt"></i>Downtown Opelika, AL</p>
-    <p><a href="https://www.facebook.com/GabrielSmithAttorney/">Facebook</a></p>
-    <p>© 2025 Law Office of Gabriel Smith. All rights reserved.</p>
-    <p><a href="../../disclaimer.html">Disclaimer</a></p>
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-phone">
+     </i>
+     <a href="tel:+13347501729">
+      (334) 750-1729
+     </a>
+     or
+     <i aria-hidden="true" class="fa-solid fa-envelope">
+     </i>
+     <a href="mailto:Gabrielthecryptolawyer@gmail.com">
+      Gabrielthecryptolawyer@gmail.com
+     </a>
+    </p>
+    <p>
+     <i aria-hidden="true" class="fa-solid fa-map-marker-alt">
+     </i>
+     Downtown Opelika, AL
+    </p>
+    <p>
+     <a href="https://www.facebook.com/GabrielSmithAttorney/">
+      Facebook
+     </a>
+    </p>
+    <p>
+     © 2025 Law Office of Gabriel Smith. All rights reserved.
+    </p>
+    <p>
+     <a href="../../disclaimer.html">
+      Disclaimer
+     </a>
+    </p>
    </div>
   </footer>
-  <script src="../../js/menu.js"></script>
+  <script src="../../js/menu.js">
+  </script>
  </body>
 </html>

--- a/practice-areas/dispute-resolution/alternative-dispute-resolution.html
+++ b/practice-areas/dispute-resolution/alternative-dispute-resolution.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,31 +100,35 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Alternative Dispute Resolution
-    </h1>
-    <p class="drop-cap">
-     Disputes need not always proceed to trial. Arbitration and mediation offer private pathways to resolution while preserving time and resources.
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Alternative Dispute Resolution
+     </h1>
+     <p class="drop-cap">
+      Disputes need not always proceed to trial. Arbitration and mediation offer private pathways to resolution while preserving time and resources.
+     </p>
+    </div>
+   </section>
    <section class="alt">
-   <div class="container">
-    <p>
-     ADR allows parties to select neutral decision-makers who can focus on their unique issues. This tailored approach often yields faster outcomes than traditional litigation.
-    </p>
-    <p>
-     Preparation remains critical even outside the courtroom. We gather evidence, evaluate legal positions, and present persuasive arguments to maximize the likelihood of a favorable result.
-    </p>
-    <p>
-     If you seek efficient alternatives to litigation, reach out at <a href="tel:+13347501729">(334) 750-1729</a> or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     to discuss the best method for your dispute.
-    </p>
-   </div>
+    <div class="container">
+     <p>
+      ADR allows parties to select neutral decision-makers who can focus on their unique issues. This tailored approach often yields faster outcomes than traditional litigation.
+     </p>
+     <p>
+      Preparation remains critical even outside the courtroom. We gather evidence, evaluate legal positions, and present persuasive arguments to maximize the likelihood of a favorable result.
+     </p>
+     <p>
+      If you seek efficient alternatives to litigation, reach out at
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      to discuss the best method for your dispute.
+     </p>
+    </div>
    </section>
   </main>
   <footer class="footer">

--- a/practice-areas/dispute-resolution/arbitration-law.html
+++ b/practice-areas/dispute-resolution/arbitration-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,31 +100,35 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Arbitration
-    </h1>
-    <p class="drop-cap">
-     Many contracts contain arbitration clauses requiring disputes to be resolved outside the courtroom. We navigate these proceedings from start to finish.
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Arbitration
+     </h1>
+     <p class="drop-cap">
+      Many contracts contain arbitration clauses requiring disputes to be resolved outside the courtroom. We navigate these proceedings from start to finish.
+     </p>
+    </div>
+   </section>
    <section class="alt">
-   <div class="container">
-    <p>
-     Effective arbitration begins with a well-drafted clause. We advise businesses on language that preserves key rights while ensuring enforceability under federal and state law.
-    </p>
-    <p>
-     Once a claim arises, we guide clients through selection of arbitrators, discovery, and evidentiary hearings. Our approach balances efficiency with thorough advocacy.
-    </p>
-    <p>
-     Final awards are binding and may be confirmed by a court. For counsel on arbitration agreements or proceedings, call <a href="tel:+13347501729">(334) 750-1729</a> or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
+    <div class="container">
+     <p>
+      Effective arbitration begins with a well-drafted clause. We advise businesses on language that preserves key rights while ensuring enforceability under federal and state law.
+     </p>
+     <p>
+      Once a claim arises, we guide clients through selection of arbitrators, discovery, and evidentiary hearings. Our approach balances efficiency with thorough advocacy.
+     </p>
+     <p>
+      Final awards are binding and may be confirmed by a court. For counsel on arbitration agreements or proceedings, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
    </section>
   </main>
   <footer class="footer">

--- a/practice-areas/dispute-resolution/mediation-law.html
+++ b/practice-areas/dispute-resolution/mediation-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,31 +100,35 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Mediation
-    </h1>
-    <p class="drop-cap">
-     Mediation brings parties together with a neutral facilitator to identify common ground and craft durable solutions.
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Mediation
+     </h1>
+     <p class="drop-cap">
+      Mediation brings parties together with a neutral facilitator to identify common ground and craft durable solutions.
+     </p>
+    </div>
+   </section>
    <section class="alt">
-   <div class="container">
-    <p>
-     The mediator guides the discussion but does not impose a decision. This process empowers participants to maintain control while exploring creative settlement options.
-    </p>
-    <p>
-     Confidentiality encourages open communication, allowing parties to address underlying concerns without fear of public exposure. Agreements reached in mediation can often be incorporated into court orders.
-    </p>
-    <p>
-     If you believe mediation could resolve your dispute effectively, call <a href="tel:+13347501729">(334) 750-1729</a> or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     for more information.
-    </p>
-   </div>
+    <div class="container">
+     <p>
+      The mediator guides the discussion but does not impose a decision. This process empowers participants to maintain control while exploring creative settlement options.
+     </p>
+     <p>
+      Confidentiality encourages open communication, allowing parties to address underlying concerns without fear of public exposure. Agreements reached in mediation can often be incorporated into court orders.
+     </p>
+     <p>
+      If you believe mediation could resolve your dispute effectively, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      for more information.
+     </p>
+    </div>
    </section>
   </main>
   <footer class="footer">

--- a/practice-areas/environment-energy/cannabis-law.html
+++ b/practice-areas/environment-energy/cannabis-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,31 +100,35 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Cannabis Law
-    </h1>
-    <p class="drop-cap">
-     Alabama's medical cannabis program imposes strict licensing and operational rules. Our firm helps businesses understand and meet these requirements.
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Cannabis Law
+     </h1>
+     <p class="drop-cap">
+      Alabama's medical cannabis program imposes strict licensing and operational rules. Our firm helps businesses understand and meet these requirements.
+     </p>
+    </div>
+   </section>
    <section class="alt">
-   <div class="container">
-    <p>
-     State permits govern cultivation, processing, transport, and sale of medical cannabis. We assist with applications, background checks, and regulatory filings to establish compliance from the outset.
-    </p>
-    <p>
-     Because federal law still classifies marijuana as a controlled substance, careful attention must be paid to banking and taxation. Our guidance helps minimize risk while respecting both state and federal constraints.
-    </p>
-    <p>
-     Ongoing compliance reviews safeguard licenses and maintain good standing with regulators. To discuss your cannabis business plans, call <a href="tel:+13347501729">(334) 750-1729</a> or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
+    <div class="container">
+     <p>
+      State permits govern cultivation, processing, transport, and sale of medical cannabis. We assist with applications, background checks, and regulatory filings to establish compliance from the outset.
+     </p>
+     <p>
+      Because federal law still classifies marijuana as a controlled substance, careful attention must be paid to banking and taxation. Our guidance helps minimize risk while respecting both state and federal constraints.
+     </p>
+     <p>
+      Ongoing compliance reviews safeguard licenses and maintain good standing with regulators. To discuss your cannabis business plans, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
    </section>
   </main>
   <footer class="footer">

--- a/practice-areas/environment-energy/energy-law.html
+++ b/practice-areas/environment-energy/energy-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,31 +100,35 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Energy Law
-    </h1>
-    <p class="drop-cap">
-     Energy markets are shaped by complex regulations that govern production, transmission, and consumption. Our firm advises on compliance and transactions involving traditional and renewable resources.
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Energy Law
+     </h1>
+     <p class="drop-cap">
+      Energy markets are shaped by complex regulations that govern production, transmission, and consumption. Our firm advises on compliance and transactions involving traditional and renewable resources.
+     </p>
+    </div>
+   </section>
    <section class="alt">
-   <div class="container">
-    <p>
-     Energy projects often require navigating federal and state approvals. We assist clients with permitting, environmental review, and utility regulations, ensuring each venture proceeds within applicable legal frameworks.
-    </p>
-    <p>
-     Contracts play a central role in energy development. Whether drafting supply agreements or negotiating rights-of-way, we strive to protect the interests of landowners, operators, and investors throughout each stage of a project.
-    </p>
-    <p>
-     Regulatory compliance extends beyond initial licensing. We monitor changes in legislation and policy, advising on reporting obligations and best practices. For guidance on your energy matters, call <a href="tel:+13347501729">(334) 750-1729</a> or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
+    <div class="container">
+     <p>
+      Energy projects often require navigating federal and state approvals. We assist clients with permitting, environmental review, and utility regulations, ensuring each venture proceeds within applicable legal frameworks.
+     </p>
+     <p>
+      Contracts play a central role in energy development. Whether drafting supply agreements or negotiating rights-of-way, we strive to protect the interests of landowners, operators, and investors throughout each stage of a project.
+     </p>
+     <p>
+      Regulatory compliance extends beyond initial licensing. We monitor changes in legislation and policy, advising on reporting obligations and best practices. For guidance on your energy matters, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
    </section>
   </main>
   <footer class="footer">

--- a/practice-areas/environment-energy/oil-gas-law.html
+++ b/practice-areas/environment-energy/oil-gas-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,31 +100,35 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Oil &amp; Gas Law
-    </h1>
-    <p class="drop-cap">
-     Oil and gas operations involve intricate mineral rights and environmental oversight. We advise landowners and producers on the agreements and regulations that shape this industry.
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Oil &amp; Gas Law
+     </h1>
+     <p class="drop-cap">
+      Oil and gas operations involve intricate mineral rights and environmental oversight. We advise landowners and producers on the agreements and regulations that shape this industry.
+     </p>
+    </div>
+   </section>
    <section class="alt">
-   <div class="container">
-    <p>
-     Leasing arrangements define the relationship between property owners and operators. We prepare and review these contracts to secure fair compensation and clear responsibility for development.
-    </p>
-    <p>
-     Royalties and production payments require careful accounting. Our firm ensures compliance with reporting standards and addresses disputes over deductions or allocation of proceeds.
-    </p>
-    <p>
-     Regulatory agencies monitor drilling, pipeline construction, and site remediation. For counsel on your oil and gas ventures, call <a href="tel:+13347501729">(334) 750-1729</a> or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
+    <div class="container">
+     <p>
+      Leasing arrangements define the relationship between property owners and operators. We prepare and review these contracts to secure fair compensation and clear responsibility for development.
+     </p>
+     <p>
+      Royalties and production payments require careful accounting. Our firm ensures compliance with reporting standards and addresses disputes over deductions or allocation of proceeds.
+     </p>
+     <p>
+      Regulatory agencies monitor drilling, pipeline construction, and site remediation. For counsel on your oil and gas ventures, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
    </section>
   </main>
   <footer class="footer">

--- a/practice-areas/environment-energy/renewable-energy-law.html
+++ b/practice-areas/environment-energy/renewable-energy-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,31 +100,35 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Renewable Energy Law
-    </h1>
-    <p class="drop-cap">
-     Advances in solar and wind technology continue to transform Alabama's energy landscape. We guide developers and landowners through the regulations that govern these projects.
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Renewable Energy Law
+     </h1>
+     <p class="drop-cap">
+      Advances in solar and wind technology continue to transform Alabama's energy landscape. We guide developers and landowners through the regulations that govern these projects.
+     </p>
+    </div>
+   </section>
    <section class="alt">
-   <div class="container">
-    <p>
-     Renewable installations require careful attention to zoning, interconnection standards, and environmental review. We address these issues early so your project can proceed without unnecessary delay.
-    </p>
-    <p>
-     State and federal incentives can offset significant development costs. Our firm advises on available grants, tax credits, and power purchase agreements that support profitable clean energy ventures.
-    </p>
-    <p>
-     As regulations evolve, compliance remains key to maintaining operations. For help navigating permits and contracts in the renewable sector, call <a href="tel:+13347501729">(334) 750-1729</a> or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
+    <div class="container">
+     <p>
+      Renewable installations require careful attention to zoning, interconnection standards, and environmental review. We address these issues early so your project can proceed without unnecessary delay.
+     </p>
+     <p>
+      State and federal incentives can offset significant development costs. Our firm advises on available grants, tax credits, and power purchase agreements that support profitable clean energy ventures.
+     </p>
+     <p>
+      As regulations evolve, compliance remains key to maintaining operations. For help navigating permits and contracts in the renewable sector, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
    </section>
   </main>
   <footer class="footer">

--- a/practice-areas/family-estate/adoption-law.html
+++ b/practice-areas/family-estate/adoption-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/family-estate/elder-law.html
+++ b/practice-areas/family-estate/elder-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/family-estate/estate-planning.html
+++ b/practice-areas/family-estate/estate-planning.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/family-estate/family-law.html
+++ b/practice-areas/family-estate/family-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/family-estate/trusts-estates-law.html
+++ b/practice-areas/family-estate/trusts-estates-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/family-estate/wills-probate-law.html
+++ b/practice-areas/family-estate/wills-probate-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/finance-services/banking-finance-law.html
+++ b/practice-areas/finance-services/banking-finance-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">
@@ -148,7 +152,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/finance-services/bankruptcy-law.html
+++ b/practice-areas/finance-services/bankruptcy-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">
@@ -148,7 +152,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/finance-services/capital-markets-law.html
+++ b/practice-areas/finance-services/capital-markets-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">
@@ -148,7 +152,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/finance-services/cryptocurrency-recovery-law.html
+++ b/practice-areas/finance-services/cryptocurrency-recovery-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -114,7 +114,10 @@
      Cryptocurrency law is rapidly evolving. By combining technical insight with established asset recovery tools, we aim to restore clients’ holdings and deter further fraud.
     </p>
     <p>
-     <a href="/contact.html">Contact us</a> if you need help recovering lost cryptocurrency assets.
+     <a href="/contact.html">
+      Contact us
+     </a>
+     if you need help recovering lost cryptocurrency assets.
     </p>
    </div>
   </section>

--- a/practice-areas/finance-services/financial-services-regulation.html
+++ b/practice-areas/finance-services/financial-services-regulation.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">
@@ -148,7 +152,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/healthcare-life-sciences/biotechnology-life-sciences-law.html
+++ b/practice-areas/healthcare-life-sciences/biotechnology-life-sciences-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -107,31 +109,35 @@
    </div>
   </section>
   <main id="main-content">
-  <section class="alt">
-   <div class="container">
-    <p>
-     Our firm helps laboratories, start-ups, and established companies secure patents and safeguard proprietary technology. Effective intellectual property strategies encourage investment and allow new discoveries to reach the market.
-    </p>
-    <p>
-     We counsel clients on compliance with federal regulations governing human and animal research, including Institutional Review Board requirements. Adhering to these rules is essential for ethical investigations and future commercialization.
-    </p>
-    <p>
-     Collaborations with universities, hospitals, and investors require careful contract drafting. We assist with licensing agreements, joint development projects, and technology transfers to ensure rights are clearly defined.
-    </p>
-    <p>
-     To discuss the legal framework surrounding your life sciences venture, contact us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Our firm helps laboratories, start-ups, and established companies secure patents and safeguard proprietary technology. Effective intellectual property strategies encourage investment and allow new discoveries to reach the market.
+     </p>
+     <p>
+      We counsel clients on compliance with federal regulations governing human and animal research, including Institutional Review Board requirements. Adhering to these rules is essential for ethical investigations and future commercialization.
+     </p>
+     <p>
+      Collaborations with universities, hospitals, and investors require careful contract drafting. We assist with licensing agreements, joint development projects, and technology transfers to ensure rights are clearly defined.
+     </p>
+     <p>
+      To discuss the legal framework surrounding your life sciences venture, contact us at (334) 750-1729 or
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">
@@ -154,7 +160,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/healthcare-life-sciences/healthcare-law.html
+++ b/practice-areas/healthcare-life-sciences/healthcare-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -107,31 +109,35 @@
    </div>
   </section>
   <main id="main-content">
-  <section class="alt">
-   <div class="container">
-    <p>
-     Our firm advises hospitals, clinics, and individual practitioners on compliance with statutes such as the Health Insurance Portability and Accountability Act and the Stark Law. Guidance covers billing practices, privacy obligations, and relationships with referral sources.
-    </p>
-    <p>
-     We assist with licensing, certification, and the contractual matters that arise in transactions, including practice acquisitions and joint ventures. Proper structuring protects both financial interests and regulatory standing.
-    </p>
-    <p>
-     When disputes occur, we represent health care professionals before administrative boards and in court. Whether the issue involves reimbursement, credentialing, or disciplinary proceedings, we work to safeguard your ability to serve patients.
-    </p>
-    <p>
-     For counsel tailored to your health care practice, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . We stand ready to help you navigate this demanding area of law.
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Our firm advises hospitals, clinics, and individual practitioners on compliance with statutes such as the Health Insurance Portability and Accountability Act and the Stark Law. Guidance covers billing practices, privacy obligations, and relationships with referral sources.
+     </p>
+     <p>
+      We assist with licensing, certification, and the contractual matters that arise in transactions, including practice acquisitions and joint ventures. Proper structuring protects both financial interests and regulatory standing.
+     </p>
+     <p>
+      When disputes occur, we represent health care professionals before administrative boards and in court. Whether the issue involves reimbursement, credentialing, or disciplinary proceedings, we work to safeguard your ability to serve patients.
+     </p>
+     <p>
+      For counsel tailored to your health care practice, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . We stand ready to help you navigate this demanding area of law.
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">
@@ -154,7 +160,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/healthcare-life-sciences/medical-malpractice-law.html
+++ b/practice-areas/healthcare-life-sciences/medical-malpractice-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -107,31 +109,35 @@
    </div>
   </section>
   <main id="main-content">
-  <section class="alt">
-   <div class="container">
-    <p>
-     We review medical records, consult qualified experts, and evaluate whether a provider's conduct fell short of accepted practice. Identifying the proper defendants and potential theories of liability is critical at the outset.
-    </p>
-    <p>
-     Once a claim is established, we pursue negotiation or litigation to secure payment for medical expenses, lost wages, and other damages. Our firm represents both injured patients and medical professionals, giving us a well-rounded understanding of procedural requirements.
-    </p>
-    <p>
-     Medical malpractice suits require strict adherence to filing deadlines and evidentiary rules. We manage these complexities while working toward a resolution that holds negligent parties accountable or defends against unfounded allegations.
-    </p>
-    <p>
-     If you have questions about a potential malpractice claim, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     to arrange a consultation.
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      We review medical records, consult qualified experts, and evaluate whether a provider's conduct fell short of accepted practice. Identifying the proper defendants and potential theories of liability is critical at the outset.
+     </p>
+     <p>
+      Once a claim is established, we pursue negotiation or litigation to secure payment for medical expenses, lost wages, and other damages. Our firm represents both injured patients and medical professionals, giving us a well-rounded understanding of procedural requirements.
+     </p>
+     <p>
+      Medical malpractice suits require strict adherence to filing deadlines and evidentiary rules. We manage these complexities while working toward a resolution that holds negligent parties accountable or defends against unfounded allegations.
+     </p>
+     <p>
+      If you have questions about a potential malpractice claim, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      to arrange a consultation.
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">
@@ -154,7 +160,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/healthcare-life-sciences/pharmaceutical-medical-device-law.html
+++ b/practice-areas/healthcare-life-sciences/pharmaceutical-medical-device-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -107,31 +109,35 @@
    </div>
   </section>
   <main id="main-content">
-  <section class="alt">
-   <div class="container">
-    <p>
-     We advise on every stage of bringing a therapy or device to market, from preclinical research through FDA submission. Our services include preparing regulatory filings and addressing agency questions.
-    </p>
-    <p>
-     Marketing and distribution carry their own requirements. We help ensure promotional materials, labeling, and distribution agreements meet federal standards and minimize enforcement actions.
-    </p>
-    <p>
-     When disputes arise, we defend clients in product liability suits and government investigations. Timely action can limit financial exposure and protect a company's reputation.
-    </p>
-    <p>
-     For guidance in this highly regulated industry, reach us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
-  <section class="back-to-top-section">
-   <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
-   </div>
-  </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      We advise on every stage of bringing a therapy or device to market, from preclinical research through FDA submission. Our services include preparing regulatory filings and addressing agency questions.
+     </p>
+     <p>
+      Marketing and distribution carry their own requirements. We help ensure promotional materials, labeling, and distribution agreements meet federal standards and minimize enforcement actions.
+     </p>
+     <p>
+      When disputes arise, we defend clients in product liability suits and government investigations. Timely action can limit financial exposure and protect a company's reputation.
+     </p>
+     <p>
+      For guidance in this highly regulated industry, reach us at (334) 750-1729 or
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
+   <section class="back-to-top-section">
+    <div class="container">
+     <p class="back-to-top">
+      <a href="#hero">
+       Back to top
+      </a>
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">
@@ -154,7 +160,7 @@
      Downtown Opelika, AL
     </p>
     <p>
-     <a href="https://www.facebook.com/GabrielSmithAttorney/" target="_blank" rel="noopener noreferrer">
+     <a href="https://www.facebook.com/GabrielSmithAttorney/" rel="noopener noreferrer" target="_blank">
       Facebook
      </a>
     </p>

--- a/practice-areas/index.html
+++ b/practice-areas/index.html
@@ -25,8 +25,8 @@
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
-  <link href="../css/style.css" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header class="header">
@@ -100,32 +100,33 @@
       Civil Litigation
      </h2>
      <ul>
-     <li>
-      <a href="civil-litigation/appellate-law.html">
-       Appellate Law
-      </a>
-     </li>
-     <li>
-      <a href="civil-litigation/civil-litigation.html">
-       Civil Litigation
-      </a>
-     </li>
-     <li>
-      <a href="civil-litigation/class-actions.html">
-       Class Actions
-      </a>
-     </li>
-     <li>
-      <a href="civil-litigation/personal-injury.html">
-       Personal Injury
-      </a>
-     </li>
-     <li>
-      <a href="civil-litigation/mass-tort-law.html">
-       Mass Tort Law
-      </a>
-     </li>
-    </ul>
+      <li>
+       <a href="civil-litigation/appellate-law.html">
+        Appellate Law
+       </a>
+      </li>
+      <li>
+       <a href="civil-litigation/civil-litigation.html">
+        Civil Litigation
+       </a>
+      </li>
+      <li>
+       <a href="civil-litigation/class-actions.html">
+        Class Actions
+       </a>
+      </li>
+      <li>
+       <a href="civil-litigation/personal-injury.html">
+        Personal Injury
+       </a>
+      </li>
+      <li>
+       <a href="civil-litigation/mass-tort-law.html">
+        Mass Tort Law
+       </a>
+      </li>
+     </ul>
+    </div>
    </section>
    <section class="section-alt">
     <div class="container">
@@ -133,26 +134,26 @@
       Corporate Business
      </h2>
      <ul>
-     <li>
-      <a href="corporate-business/corporate-law.html">
-       Corporate Law
-      </a>
-     </li>
-     <li>
-      <a href="corporate-business/franchise-law.html">
-       Franchise Law
-      </a>
-     </li>
-     <li>
-      <a href="corporate-business/mergers-acquisitions-law.html">
-       Mergers Acquisitions Law
-      </a>
-     </li>
-     <li>
-      <a href="corporate-business/venture-capital-law.html">
-       Venture Capital Law
-      </a>
-     </li>
+      <li>
+       <a href="corporate-business/corporate-law.html">
+        Corporate Law
+       </a>
+      </li>
+      <li>
+       <a href="corporate-business/franchise-law.html">
+        Franchise Law
+       </a>
+      </li>
+      <li>
+       <a href="corporate-business/mergers-acquisitions-law.html">
+        Mergers Acquisitions Law
+       </a>
+      </li>
+      <li>
+       <a href="corporate-business/venture-capital-law.html">
+        Venture Capital Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -162,26 +163,26 @@
       Criminal Law
      </h2>
      <ul>
-     <li>
-      <a href="criminal-law/criminal-defense.html">
-       Criminal Defense
-      </a>
-     </li>
-     <li>
-      <a href="criminal-law/hate-crime-law.html">
-       Hate Crime Law
-      </a>
-     </li>
-     <li>
-      <a href="criminal-law/juvenile-law.html">
-       Juvenile Law
-      </a>
-     </li>
-     <li>
-      <a href="criminal-law/white-collar-criminal-defense.html">
-       White Collar Criminal Defense
-      </a>
-     </li>
+      <li>
+       <a href="criminal-law/criminal-defense.html">
+        Criminal Defense
+       </a>
+      </li>
+      <li>
+       <a href="criminal-law/hate-crime-law.html">
+        Hate Crime Law
+       </a>
+      </li>
+      <li>
+       <a href="criminal-law/juvenile-law.html">
+        Juvenile Law
+       </a>
+      </li>
+      <li>
+       <a href="criminal-law/white-collar-criminal-defense.html">
+        White Collar Criminal Defense
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -191,21 +192,21 @@
       Dispute Resolution
      </h2>
      <ul>
-     <li>
-      <a href="dispute-resolution/alternative-dispute-resolution.html">
-       Alternative Dispute Resolution
-      </a>
-     </li>
-     <li>
-      <a href="dispute-resolution/arbitration-law.html">
-       Arbitration Law
-      </a>
-     </li>
-     <li>
-      <a href="dispute-resolution/mediation-law.html">
-       Mediation Law
-      </a>
-     </li>
+      <li>
+       <a href="dispute-resolution/alternative-dispute-resolution.html">
+        Alternative Dispute Resolution
+       </a>
+      </li>
+      <li>
+       <a href="dispute-resolution/arbitration-law.html">
+        Arbitration Law
+       </a>
+      </li>
+      <li>
+       <a href="dispute-resolution/mediation-law.html">
+        Mediation Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -215,26 +216,26 @@
       Environment Energy
      </h2>
      <ul>
-     <li>
-      <a href="environment-energy/cannabis-law.html">
-       Cannabis Law
-      </a>
-     </li>
-     <li>
-      <a href="environment-energy/energy-law.html">
-       Energy Law
-      </a>
-     </li>
-     <li>
-      <a href="environment-energy/oil-gas-law.html">
-       Oil Gas Law
-      </a>
-     </li>
-     <li>
-      <a href="environment-energy/renewable-energy-law.html">
-       Renewable Energy Law
-      </a>
-     </li>
+      <li>
+       <a href="environment-energy/cannabis-law.html">
+        Cannabis Law
+       </a>
+      </li>
+      <li>
+       <a href="environment-energy/energy-law.html">
+        Energy Law
+       </a>
+      </li>
+      <li>
+       <a href="environment-energy/oil-gas-law.html">
+        Oil Gas Law
+       </a>
+      </li>
+      <li>
+       <a href="environment-energy/renewable-energy-law.html">
+        Renewable Energy Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -244,36 +245,36 @@
       Family Estate
      </h2>
      <ul>
-     <li>
-      <a href="family-estate/adoption-law.html">
-       Adoption Law
-      </a>
-     </li>
-     <li>
-      <a href="family-estate/elder-law.html">
-       Elder Law
-      </a>
-     </li>
-     <li>
-      <a href="family-estate/estate-planning.html">
-       Estate Planning
-      </a>
-     </li>
-     <li>
-      <a href="family-estate/family-law.html">
-       Family Law
-      </a>
-     </li>
-     <li>
-      <a href="family-estate/trusts-estates-law.html">
-       Trusts Estates Law
-      </a>
-     </li>
-     <li>
-      <a href="family-estate/wills-probate-law.html">
-       Wills Probate Law
-      </a>
-     </li>
+      <li>
+       <a href="family-estate/adoption-law.html">
+        Adoption Law
+       </a>
+      </li>
+      <li>
+       <a href="family-estate/elder-law.html">
+        Elder Law
+       </a>
+      </li>
+      <li>
+       <a href="family-estate/estate-planning.html">
+        Estate Planning
+       </a>
+      </li>
+      <li>
+       <a href="family-estate/family-law.html">
+        Family Law
+       </a>
+      </li>
+      <li>
+       <a href="family-estate/trusts-estates-law.html">
+        Trusts Estates Law
+       </a>
+      </li>
+      <li>
+       <a href="family-estate/wills-probate-law.html">
+        Wills Probate Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -283,31 +284,31 @@
       Finance Services
      </h2>
      <ul>
-     <li>
-      <a href="finance-services/banking-finance-law.html">
-       Banking Finance Law
-      </a>
-     </li>
-     <li>
-      <a href="finance-services/bankruptcy-law.html">
-       Bankruptcy Law
-      </a>
-     </li>
-     <li>
-      <a href="finance-services/capital-markets-law.html">
-       Capital Markets Law
-      </a>
-     </li>
-     <li>
-      <a href="finance-services/cryptocurrency-recovery-law.html">
-       Cryptocurrency Recovery Law
-      </a>
-     </li>
-     <li>
-      <a href="finance-services/financial-services-regulation.html">
-       Financial Services Regulation
-      </a>
-     </li>
+      <li>
+       <a href="finance-services/banking-finance-law.html">
+        Banking Finance Law
+       </a>
+      </li>
+      <li>
+       <a href="finance-services/bankruptcy-law.html">
+        Bankruptcy Law
+       </a>
+      </li>
+      <li>
+       <a href="finance-services/capital-markets-law.html">
+        Capital Markets Law
+       </a>
+      </li>
+      <li>
+       <a href="finance-services/cryptocurrency-recovery-law.html">
+        Cryptocurrency Recovery Law
+       </a>
+      </li>
+      <li>
+       <a href="finance-services/financial-services-regulation.html">
+        Financial Services Regulation
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -317,26 +318,26 @@
       Healthcare Life Sciences
      </h2>
      <ul>
-     <li>
-      <a href="healthcare-life-sciences/biotechnology-life-sciences-law.html">
-       Biotechnology Life Sciences Law
-      </a>
-     </li>
-     <li>
-      <a href="healthcare-life-sciences/healthcare-law.html">
-       Healthcare Law
-      </a>
-     </li>
-     <li>
-      <a href="healthcare-life-sciences/medical-malpractice-law.html">
-       Medical Malpractice Law
-      </a>
-     </li>
-     <li>
-      <a href="healthcare-life-sciences/pharmaceutical-medical-device-law.html">
-       Pharmaceutical Medical Device Law
-      </a>
-     </li>
+      <li>
+       <a href="healthcare-life-sciences/biotechnology-life-sciences-law.html">
+        Biotechnology Life Sciences Law
+       </a>
+      </li>
+      <li>
+       <a href="healthcare-life-sciences/healthcare-law.html">
+        Healthcare Law
+       </a>
+      </li>
+      <li>
+       <a href="healthcare-life-sciences/medical-malpractice-law.html">
+        Medical Malpractice Law
+       </a>
+      </li>
+      <li>
+       <a href="healthcare-life-sciences/pharmaceutical-medical-device-law.html">
+        Pharmaceutical Medical Device Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -346,21 +347,21 @@
       Intellectual Property
      </h2>
      <ul>
-     <li>
-      <a href="intellectual-property/copyright-law.html">
-       Copyright Law
-      </a>
-     </li>
-     <li>
-      <a href="intellectual-property/intellectual-property-law.html">
-       Intellectual Property Law
-      </a>
-     </li>
-     <li>
-      <a href="intellectual-property/trademark-law.html">
-       Trademark Law
-      </a>
-     </li>
+      <li>
+       <a href="intellectual-property/copyright-law.html">
+        Copyright Law
+       </a>
+      </li>
+      <li>
+       <a href="intellectual-property/intellectual-property-law.html">
+        Intellectual Property Law
+       </a>
+      </li>
+      <li>
+       <a href="intellectual-property/trademark-law.html">
+        Trademark Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -370,26 +371,26 @@
       Labor Employment
      </h2>
      <ul>
-     <li>
-      <a href="labor-employment/discrimination-law.html">
-       Discrimination Law
-      </a>
-     </li>
-     <li>
-      <a href="labor-employment/erisa-employee-benefits-law.html">
-       Erisa Employee Benefits Law
-      </a>
-     </li>
-     <li>
-      <a href="labor-employment/labor-employment-law.html">
-       Labor Employment Law
-      </a>
-     </li>
-     <li>
-      <a href="labor-employment/workers-compensation-law.html">
-       Workers Compensation Law
-      </a>
-     </li>
+      <li>
+       <a href="labor-employment/discrimination-law.html">
+        Discrimination Law
+       </a>
+      </li>
+      <li>
+       <a href="labor-employment/erisa-employee-benefits-law.html">
+        Erisa Employee Benefits Law
+       </a>
+      </li>
+      <li>
+       <a href="labor-employment/labor-employment-law.html">
+        Labor Employment Law
+       </a>
+      </li>
+      <li>
+       <a href="labor-employment/workers-compensation-law.html">
+        Workers Compensation Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -399,26 +400,26 @@
       Misc
      </h2>
      <ul>
-     <li>
-      <a href="misc/immigration-law.html">
-       Immigration Law
-      </a>
-     </li>
-     <li>
-      <a href="misc/nonprofit-tax-exempt-law.html">
-       Nonprofit Tax Exempt Law
-      </a>
-     </li>
-     <li>
-      <a href="misc/pro-bono-legal-services.html">
-       Pro Bono Legal Services
-      </a>
-     </li>
-     <li>
-      <a href="misc/public-international-law.html">
-       Public International Law
-      </a>
-     </li>
+      <li>
+       <a href="misc/immigration-law.html">
+        Immigration Law
+       </a>
+      </li>
+      <li>
+       <a href="misc/nonprofit-tax-exempt-law.html">
+        Nonprofit Tax Exempt Law
+       </a>
+      </li>
+      <li>
+       <a href="misc/pro-bono-legal-services.html">
+        Pro Bono Legal Services
+       </a>
+      </li>
+      <li>
+       <a href="misc/public-international-law.html">
+        Public International Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -428,21 +429,21 @@
       Real Estate Construction
      </h2>
      <ul>
-     <li>
-      <a href="real-estate-construction/construction-law.html">
-       Construction Law
-      </a>
-     </li>
-     <li>
-      <a href="real-estate-construction/landlord-tenant-law.html">
-       Landlord Tenant Law
-      </a>
-     </li>
-     <li>
-      <a href="real-estate-construction/real-estate-law.html">
-       Real Estate Law
-      </a>
-     </li>
+      <li>
+       <a href="real-estate-construction/construction-law.html">
+        Construction Law
+       </a>
+      </li>
+      <li>
+       <a href="real-estate-construction/landlord-tenant-law.html">
+        Landlord Tenant Law
+       </a>
+      </li>
+      <li>
+       <a href="real-estate-construction/real-estate-law.html">
+        Real Estate Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -452,26 +453,26 @@
       Regulatory Compliance
      </h2>
      <ul>
-     <li>
-      <a href="regulatory-compliance/administrative-law.html">
-       Administrative Law
-      </a>
-     </li>
-     <li>
-      <a href="regulatory-compliance/election-law.html">
-       Election Law
-      </a>
-     </li>
-     <li>
-      <a href="regulatory-compliance/environmental-natural-resources-law.html">
-       Environmental Natural Resources Law
-      </a>
-     </li>
-     <li>
-      <a href="regulatory-compliance/public-policy-government-affairs-law.html">
-       Public Policy Government Affairs Law
-      </a>
-     </li>
+      <li>
+       <a href="regulatory-compliance/administrative-law.html">
+        Administrative Law
+       </a>
+      </li>
+      <li>
+       <a href="regulatory-compliance/election-law.html">
+        Election Law
+       </a>
+      </li>
+      <li>
+       <a href="regulatory-compliance/environmental-natural-resources-law.html">
+        Environmental Natural Resources Law
+       </a>
+      </li>
+      <li>
+       <a href="regulatory-compliance/public-policy-government-affairs-law.html">
+        Public Policy Government Affairs Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -481,21 +482,21 @@
       Sports Entertainment
      </h2>
      <ul>
-     <li>
-      <a href="sports-entertainment/entertainment-sports-law.html">
-       Entertainment Sports Law
-      </a>
-     </li>
-     <li>
-      <a href="sports-entertainment/gaming-law.html">
-       Gaming Law
-      </a>
-     </li>
-     <li>
-      <a href="sports-entertainment/sports-law.html">
-       Sports Law
-      </a>
-     </li>
+      <li>
+       <a href="sports-entertainment/entertainment-sports-law.html">
+        Entertainment Sports Law
+       </a>
+      </li>
+      <li>
+       <a href="sports-entertainment/gaming-law.html">
+        Gaming Law
+       </a>
+      </li>
+      <li>
+       <a href="sports-entertainment/sports-law.html">
+        Sports Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -505,26 +506,26 @@
       Technology Data Privacy
      </h2>
      <ul>
-     <li>
-      <a href="technology-data-privacy/cybersecurity-data-privacy-law.html">
-       Cybersecurity Data Privacy Law
-      </a>
-     </li>
-     <li>
-      <a href="technology-data-privacy/internet-ecommerce-law.html">
-       Internet Ecommerce Law
-      </a>
-     </li>
-     <li>
-      <a href="technology-data-privacy/technology-law.html">
-       Technology Law
-      </a>
-     </li>
-     <li>
-      <a href="technology-data-privacy/telecommunications-law.html">
-       Telecommunications Law
-      </a>
-     </li>
+      <li>
+       <a href="technology-data-privacy/cybersecurity-data-privacy-law.html">
+        Cybersecurity Data Privacy Law
+       </a>
+      </li>
+      <li>
+       <a href="technology-data-privacy/internet-ecommerce-law.html">
+        Internet Ecommerce Law
+       </a>
+      </li>
+      <li>
+       <a href="technology-data-privacy/technology-law.html">
+        Technology Law
+       </a>
+      </li>
+      <li>
+       <a href="technology-data-privacy/telecommunications-law.html">
+        Telecommunications Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>
@@ -534,21 +535,21 @@
       Transportation Maritime
      </h2>
      <ul>
-     <li>
-      <a href="transportation-maritime/admiralty-maritime-law.html">
-       Admiralty Maritime Law
-      </a>
-     </li>
-     <li>
-      <a href="transportation-maritime/aviation-law.html">
-       Aviation Law
-      </a>
-     </li>
-     <li>
-      <a href="transportation-maritime/railroad-transportation-law.html">
-       Railroad Transportation Law
-      </a>
-     </li>
+      <li>
+       <a href="transportation-maritime/admiralty-maritime-law.html">
+        Admiralty Maritime Law
+       </a>
+      </li>
+      <li>
+       <a href="transportation-maritime/aviation-law.html">
+        Aviation Law
+       </a>
+      </li>
+      <li>
+       <a href="transportation-maritime/railroad-transportation-law.html">
+        Railroad Transportation Law
+       </a>
+      </li>
      </ul>
     </div>
    </section>

--- a/practice-areas/intellectual-property/copyright-law.html
+++ b/practice-areas/intellectual-property/copyright-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -96,33 +96,33 @@
    </div>
   </header>
   <main>
-  <section class="hero">
-   <div class="container">
-    <h1>
-     Copyright Law
-    </h1>
-    <p class="drop-cap">
-     Copyright law grants authors the exclusive right to control the distribution and adaptation of their work. We help creators protect and capitalize on their original expression.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Registration is the strongest step toward enforcing your rights. We prepare filings, advise on ownership questions, and monitor deadlines so that your work remains secure.
-    </p>
-    <p>
-     Should infringement occur, our firm acts quickly with notices, negotiations, and litigation when necessary. We aim to stop unauthorized use while preserving your reputation.
-    </p>
-    <p>
-     For copyright guidance, reach the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . Your creativity deserves diligent protection.
-    </p>
-   </div>
-  </section>
+   <section class="hero">
+    <div class="container">
+     <h1>
+      Copyright Law
+     </h1>
+     <p class="drop-cap">
+      Copyright law grants authors the exclusive right to control the distribution and adaptation of their work. We help creators protect and capitalize on their original expression.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Registration is the strongest step toward enforcing your rights. We prepare filings, advise on ownership questions, and monitor deadlines so that your work remains secure.
+     </p>
+     <p>
+      Should infringement occur, our firm acts quickly with notices, negotiations, and litigation when necessary. We aim to stop unauthorized use while preserving your reputation.
+     </p>
+     <p>
+      For copyright guidance, reach the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . Your creativity deserves diligent protection.
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/intellectual-property/intellectual-property-law.html
+++ b/practice-areas/intellectual-property/intellectual-property-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -96,33 +96,37 @@
    </div>
   </header>
   <main>
-  <section class="hero">
-   <div class="container">
-    <h1>
-     Intellectual Property Law
-    </h1>
-    <p class="drop-cap">
-     Intellectual property safeguards creative achievements and commercial innovations. Our firm assists clients in securing rights that encourage growth and protect hard-earned ideas.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     From patents and trademarks to copyrights and trade secrets, we analyze which protections best serve your goals. By preparing thorough applications and maintaining clear documentation, we help secure lasting value from your creations.
-    </p>
-    <p>
-     We counsel on licensing, technology transfers, and enforcement actions when infringement threatens your position in the market. Our guidance blends legal skill with practical insight to preserve competitive advantages.
-    </p>
-    <p>
-     To discuss intellectual property strategies, contact the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . Connect on Facebook at <a href="https://www.facebook.com/GabrielSmithAttorney/">Providing Justice 4U</a> for updates.
-    </p>
-   </div>
-  </section>
+   <section class="hero">
+    <div class="container">
+     <h1>
+      Intellectual Property Law
+     </h1>
+     <p class="drop-cap">
+      Intellectual property safeguards creative achievements and commercial innovations. Our firm assists clients in securing rights that encourage growth and protect hard-earned ideas.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      From patents and trademarks to copyrights and trade secrets, we analyze which protections best serve your goals. By preparing thorough applications and maintaining clear documentation, we help secure lasting value from your creations.
+     </p>
+     <p>
+      We counsel on licensing, technology transfers, and enforcement actions when infringement threatens your position in the market. Our guidance blends legal skill with practical insight to preserve competitive advantages.
+     </p>
+     <p>
+      To discuss intellectual property strategies, contact the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . Connect on Facebook at
+      <a href="https://www.facebook.com/GabrielSmithAttorney/">
+       Providing Justice 4U
+      </a>
+      for updates.
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/intellectual-property/trademark-law.html
+++ b/practice-areas/intellectual-property/trademark-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -96,33 +96,33 @@
    </div>
   </header>
   <main>
-  <section class="hero">
-   <div class="container">
-    <h1>
-     Trademark Law
-    </h1>
-    <p class="drop-cap">
-     Trademarks distinguish your goods and services from those of others. Proper registration protects your brand and helps build lasting recognition.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     We conduct thorough searches to assess the availability of your mark and prepare applications that meet federal requirements. Our firm also monitors renewals and advises on international filings when expansion is planned.
-    </p>
-    <p>
-     If another business adopts a confusingly similar name or logo, we evaluate the impact on your reputation and pursue solutions ranging from settlement to litigation.
-    </p>
-    <p>
-     For guidance on protecting your brand, contact the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+   <section class="hero">
+    <div class="container">
+     <h1>
+      Trademark Law
+     </h1>
+     <p class="drop-cap">
+      Trademarks distinguish your goods and services from those of others. Proper registration protects your brand and helps build lasting recognition.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      We conduct thorough searches to assess the availability of your mark and prepare applications that meet federal requirements. Our firm also monitors renewals and advises on international filings when expansion is planned.
+     </p>
+     <p>
+      If another business adopts a confusingly similar name or logo, we evaluate the impact on your reputation and pursue solutions ranging from settlement to litigation.
+     </p>
+     <p>
+      For guidance on protecting your brand, contact the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/labor-employment/discrimination-law.html
+++ b/practice-areas/labor-employment/discrimination-law.html
@@ -28,7 +28,9 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -94,30 +96,30 @@
    </div>
   </section>
   <main id="main-content">
-  <section>
-   <div class="container">
-    <p>
-     The Equal Employment Opportunity Commission enforces statutes such as Title VII and the Americans with Disabilities Act. Claims often begin with a charge filed through the EEOC, followed by investigation and potential litigation. Strict deadlines apply, making prompt consultation vital.
-    </p>
-    <p>
-     Evidence in discrimination cases may include personnel records, witness statements, and patterns of unequal treatment. Document preservation is crucial for both sides, as is a thorough understanding of the employer’s policies and practices.
-    </p>
-    <p>
-     Employers who foster inclusive workplaces benefit from reduced turnover and improved morale. Training and clear reporting procedures help prevent misconduct before it becomes an expensive lawsuit.
-    </p>
-    <p>
-     For advice on discrimination issues, reach me at
-     <a href="tel:+13347501729">
-      (334) 750-1729
-     </a>
-     or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+   <section>
+    <div class="container">
+     <p>
+      The Equal Employment Opportunity Commission enforces statutes such as Title VII and the Americans with Disabilities Act. Claims often begin with a charge filed through the EEOC, followed by investigation and potential litigation. Strict deadlines apply, making prompt consultation vital.
+     </p>
+     <p>
+      Evidence in discrimination cases may include personnel records, witness statements, and patterns of unequal treatment. Document preservation is crucial for both sides, as is a thorough understanding of the employer’s policies and practices.
+     </p>
+     <p>
+      Employers who foster inclusive workplaces benefit from reduced turnover and improved morale. Training and clear reporting procedures help prevent misconduct before it becomes an expensive lawsuit.
+     </p>
+     <p>
+      For advice on discrimination issues, reach me at
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/labor-employment/erisa-employee-benefits-law.html
+++ b/practice-areas/labor-employment/erisa-employee-benefits-law.html
@@ -28,7 +28,9 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -94,30 +96,30 @@
    </div>
   </section>
   <main id="main-content">
-  <section>
-   <div class="container">
-    <p>
-     ERISA sets standards for pension and health plans in private industry. It requires transparency in plan administration and fiduciary responsibility from those managing funds. Compliance mistakes can lead to heavy penalties and jeopardize tax advantages.
-    </p>
-    <p>
-     Participants may bring claims for denied benefits or breaches of fiduciary duty. These cases often hinge on careful review of plan documents and the administrative record, as courts typically defer to the plan’s written terms.
-    </p>
-    <p>
-     Employers must keep plan documents current and notify employees of any changes. Proper reporting to the Department of Labor and the Internal Revenue Service helps maintain the plan’s qualified status.
-    </p>
-    <p>
-     If you have questions about a benefits plan, please call
-     <a href="tel:+13347501729">
-      (334) 750-1729
-     </a>
-     or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+   <section>
+    <div class="container">
+     <p>
+      ERISA sets standards for pension and health plans in private industry. It requires transparency in plan administration and fiduciary responsibility from those managing funds. Compliance mistakes can lead to heavy penalties and jeopardize tax advantages.
+     </p>
+     <p>
+      Participants may bring claims for denied benefits or breaches of fiduciary duty. These cases often hinge on careful review of plan documents and the administrative record, as courts typically defer to the plan’s written terms.
+     </p>
+     <p>
+      Employers must keep plan documents current and notify employees of any changes. Proper reporting to the Department of Labor and the Internal Revenue Service helps maintain the plan’s qualified status.
+     </p>
+     <p>
+      If you have questions about a benefits plan, please call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/labor-employment/labor-employment-law.html
+++ b/practice-areas/labor-employment/labor-employment-law.html
@@ -28,7 +28,9 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -94,30 +96,30 @@
    </div>
   </section>
   <main id="main-content">
-  <section>
-   <div class="container">
-    <p>
-     Labor and employment law covers hiring, workplace policies, and termination. Employers must comply with statutes such as the Fair Labor Standards Act and the Family and Medical Leave Act, while workers are entitled to fair wages and safe conditions. Each case demands an analysis of contracts and company practices.
-    </p>
-    <p>
-     Disputes may involve wrongful termination, wage claims, or labor union matters. Timely investigation and a clear strategy often prevent small issues from escalating into costly litigation. When negotiation fails, I provide assertive advocacy in state or federal court.
-    </p>
-    <p>
-     Employee handbooks and training programs help organizations maintain consistent standards. Crafting these documents carefully reduces risk and fosters a respectful workplace.
-    </p>
-    <p>
-     For assistance with any employment concern, call
-     <a href="tel:+13347501729">
-      (334) 750-1729
-     </a>
-     or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+   <section>
+    <div class="container">
+     <p>
+      Labor and employment law covers hiring, workplace policies, and termination. Employers must comply with statutes such as the Fair Labor Standards Act and the Family and Medical Leave Act, while workers are entitled to fair wages and safe conditions. Each case demands an analysis of contracts and company practices.
+     </p>
+     <p>
+      Disputes may involve wrongful termination, wage claims, or labor union matters. Timely investigation and a clear strategy often prevent small issues from escalating into costly litigation. When negotiation fails, I provide assertive advocacy in state or federal court.
+     </p>
+     <p>
+      Employee handbooks and training programs help organizations maintain consistent standards. Crafting these documents carefully reduces risk and fosters a respectful workplace.
+     </p>
+     <p>
+      For assistance with any employment concern, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/labor-employment/workers-compensation-law.html
+++ b/practice-areas/labor-employment/workers-compensation-law.html
@@ -28,7 +28,9 @@
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
  </head>
  <body>
-  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header>
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -94,30 +96,30 @@
    </div>
   </section>
   <main id="main-content">
-  <section>
-   <div class="container">
-    <p>
-     Workers compensation provides medical coverage and wage replacement for employees hurt in the course of employment. Employers must carry insurance or qualify as self-insured. Claims require prompt notice and documentation of the injury.
-    </p>
-    <p>
-     Disputes arise when insurers contest the severity of an injury or the connection to work. Hearings before the Alabama Department of Labor may be necessary to determine eligibility. An experienced attorney can gather medical evidence and present a clear case for benefits.
-    </p>
-    <p>
-     Some injuries also implicate third-party liability, such as defective machinery or negligent subcontractors. Exploring these avenues can lead to additional compensation beyond the workers compensation system.
-    </p>
-    <p>
-     To discuss an on-the-job injury, call
-     <a href="tel:+13347501729">
-      (334) 750-1729
-     </a>
-     or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+   <section>
+    <div class="container">
+     <p>
+      Workers compensation provides medical coverage and wage replacement for employees hurt in the course of employment. Employers must carry insurance or qualify as self-insured. Claims require prompt notice and documentation of the injury.
+     </p>
+     <p>
+      Disputes arise when insurers contest the severity of an injury or the connection to work. Hearings before the Alabama Department of Labor may be necessary to determine eligibility. An experienced attorney can gather medical evidence and present a clear case for benefits.
+     </p>
+     <p>
+      Some injuries also implicate third-party liability, such as defective machinery or negligent subcontractors. Exploring these avenues can lead to additional compensation beyond the workers compensation system.
+     </p>
+     <p>
+      To discuss an on-the-job injury, call
+      <a href="tel:+13347501729">
+       (334) 750-1729
+      </a>
+      or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/misc/immigration-law.html
+++ b/practice-areas/misc/immigration-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header class="header">
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,39 +100,39 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Immigration Law
-    </h1>
-    <p class="drop-cap">
-     Immigration matters involve meticulous paperwork and firm deadlines. Our office assists with every step, from petitions for temporary visas to applications for permanent residency.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Whether you seek entry on a work visa or plan to reunite family members, we prepare the necessary forms and supporting evidence to satisfy federal requirements. Accurate filings reduce delays and prevent avoidable denials.
-    </p>
-    <p>
-     Employment-based immigration often requires coordination with both United States Citizenship and Immigration Services and the Department of Labor. We guide employers and employees through compliance, ensuring that labor certifications, visa petitions, and adjustment applications proceed smoothly.
-    </p>
-    <p>
-     Families pursuing lawful permanent residence must navigate sponsorship rules and medical examinations, while naturalization applicants undergo background checks and civics testing. We explain each stage in clear terms so you understand what to expect.
-    </p>
-    <p>
-     Our firm stands ready to answer questions and protect your rights during any immigration proceeding. Call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . Find updates on Facebook at
-     <a href="https://www.facebook.com/ProvidingJustice4U">
-      Providing Justice 4U
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Immigration Law
+     </h1>
+     <p class="drop-cap">
+      Immigration matters involve meticulous paperwork and firm deadlines. Our office assists with every step, from petitions for temporary visas to applications for permanent residency.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Whether you seek entry on a work visa or plan to reunite family members, we prepare the necessary forms and supporting evidence to satisfy federal requirements. Accurate filings reduce delays and prevent avoidable denials.
+     </p>
+     <p>
+      Employment-based immigration often requires coordination with both United States Citizenship and Immigration Services and the Department of Labor. We guide employers and employees through compliance, ensuring that labor certifications, visa petitions, and adjustment applications proceed smoothly.
+     </p>
+     <p>
+      Families pursuing lawful permanent residence must navigate sponsorship rules and medical examinations, while naturalization applicants undergo background checks and civics testing. We explain each stage in clear terms so you understand what to expect.
+     </p>
+     <p>
+      Our firm stands ready to answer questions and protect your rights during any immigration proceeding. Call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . Find updates on Facebook at
+      <a href="https://www.facebook.com/ProvidingJustice4U">
+       Providing Justice 4U
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/misc/nonprofit-tax-exempt-law.html
+++ b/practice-areas/misc/nonprofit-tax-exempt-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header class="header">
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,39 +100,39 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Nonprofit &amp; Tax-Exempt Organizations
-    </h1>
-    <p class="drop-cap">
-     Charitable and community groups rely on tax-exempt status to support their missions. Our firm assists with formation, governance, and compliance.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Starting a nonprofit begins with choosing the appropriate entity type and drafting governing documents that satisfy Alabama law. We file incorporation papers and obtain the necessary state approvals.
-    </p>
-    <p>
-     Securing federal recognition as a tax-exempt organization often requires a detailed application to the Internal Revenue Service. We prepare Form 1023 or other filings, addressing questions regarding charitable purpose, board structure, and financial practices.
-    </p>
-    <p>
-     Once recognized, nonprofits must maintain proper records and submit annual reports to preserve their status. We advise on board policies, charitable solicitations, and unrelated business income to reduce the risk of penalties.
-    </p>
-    <p>
-     For guidance tailored to your organization, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . Additional resources are available on Facebook at
-     <a href="https://www.facebook.com/ProvidingJustice4U">
-      Providing Justice 4U
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Nonprofit &amp; Tax-Exempt Organizations
+     </h1>
+     <p class="drop-cap">
+      Charitable and community groups rely on tax-exempt status to support their missions. Our firm assists with formation, governance, and compliance.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Starting a nonprofit begins with choosing the appropriate entity type and drafting governing documents that satisfy Alabama law. We file incorporation papers and obtain the necessary state approvals.
+     </p>
+     <p>
+      Securing federal recognition as a tax-exempt organization often requires a detailed application to the Internal Revenue Service. We prepare Form 1023 or other filings, addressing questions regarding charitable purpose, board structure, and financial practices.
+     </p>
+     <p>
+      Once recognized, nonprofits must maintain proper records and submit annual reports to preserve their status. We advise on board policies, charitable solicitations, and unrelated business income to reduce the risk of penalties.
+     </p>
+     <p>
+      For guidance tailored to your organization, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . Additional resources are available on Facebook at
+      <a href="https://www.facebook.com/ProvidingJustice4U">
+       Providing Justice 4U
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/misc/pro-bono-legal-services.html
+++ b/practice-areas/misc/pro-bono-legal-services.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header class="header">
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,39 +100,39 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Pro Bono Legal Services
-    </h1>
-    <p class="drop-cap">
-     Our commitment to public service includes providing legal help at no cost to those who qualify.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Pro bono representation allows individuals and nonprofits facing hardship to obtain counsel when they might otherwise go unheard. Cases are selected based on legal merit and community need.
-    </p>
-    <p>
-     We review each request thoroughly to determine whether we have the resources and expertise to assist. Matters involving civil rights, housing, and family law often receive priority.
-    </p>
-    <p>
-     While pro bono services are offered without charge, they are delivered with the same care and attention afforded to paying clients. We uphold professional standards at every stage.
-    </p>
-    <p>
-     If you wish to inquire about pro bono assistance, please call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . Follow our community efforts on Facebook at
-     <a href="https://www.facebook.com/ProvidingJustice4U">
-      Providing Justice 4U
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Pro Bono Legal Services
+     </h1>
+     <p class="drop-cap">
+      Our commitment to public service includes providing legal help at no cost to those who qualify.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Pro bono representation allows individuals and nonprofits facing hardship to obtain counsel when they might otherwise go unheard. Cases are selected based on legal merit and community need.
+     </p>
+     <p>
+      We review each request thoroughly to determine whether we have the resources and expertise to assist. Matters involving civil rights, housing, and family law often receive priority.
+     </p>
+     <p>
+      While pro bono services are offered without charge, they are delivered with the same care and attention afforded to paying clients. We uphold professional standards at every stage.
+     </p>
+     <p>
+      If you wish to inquire about pro bono assistance, please call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . Follow our community efforts on Facebook at
+      <a href="https://www.facebook.com/ProvidingJustice4U">
+       Providing Justice 4U
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/misc/public-international-law.html
+++ b/practice-areas/misc/public-international-law.html
@@ -34,14 +34,16 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <a class="skip-link" href="#main-content">
+   Skip to main content
+  </a>
   <header class="header">
    <div class="navbar container">
     <a class="navbar-brand" href="/index.html">
@@ -98,39 +100,39 @@
   </header>
   <main id="main-content">
    <section class="hero">
-   <div class="container">
-    <h1>
-     Public International Law
-    </h1>
-    <p class="drop-cap">
-     Nations and international organizations rely on public international law to govern treaties, trade, and human rights obligations.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Rules of state responsibility and treaty interpretation shape how governments act on the world stage. Our firm advises clients on the implications of international agreements and customary norms, ensuring that actions comply with recognized legal standards.
-    </p>
-    <p>
-     Cross-border disputes often require coordination with foreign counsel and an understanding of jurisdictional principles. We evaluate the proper forum for claims and guide negotiations with an eye toward diplomatic considerations and enforcement of foreign judgments.
-    </p>
-    <p>
-     International regulations also affect businesses engaged in trade and investment abroad. We assist with sanctions compliance, export controls, and the resolution of investor-state disputes under applicable conventions.
-    </p>
-    <p>
-     For detailed counsel on public international matters, contact our office at (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . You can follow updates on Facebook at
-     <a href="https://www.facebook.com/ProvidingJustice4U">
-      Providing Justice 4U
-     </a>
-     .
-    </p>
-   </div>
-  </section>
+    <div class="container">
+     <h1>
+      Public International Law
+     </h1>
+     <p class="drop-cap">
+      Nations and international organizations rely on public international law to govern treaties, trade, and human rights obligations.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Rules of state responsibility and treaty interpretation shape how governments act on the world stage. Our firm advises clients on the implications of international agreements and customary norms, ensuring that actions comply with recognized legal standards.
+     </p>
+     <p>
+      Cross-border disputes often require coordination with foreign counsel and an understanding of jurisdictional principles. We evaluate the proper forum for claims and guide negotiations with an eye toward diplomatic considerations and enforcement of foreign judgments.
+     </p>
+     <p>
+      International regulations also affect businesses engaged in trade and investment abroad. We assist with sanctions compliance, export controls, and the resolution of investor-state disputes under applicable conventions.
+     </p>
+     <p>
+      For detailed counsel on public international matters, contact our office at (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . You can follow updates on Facebook at
+      <a href="https://www.facebook.com/ProvidingJustice4U">
+       Providing Justice 4U
+      </a>
+      .
+     </p>
+    </div>
+   </section>
   </main>
   <footer class="footer">
    <div class="container">

--- a/practice-areas/real-estate-construction/construction-law.html
+++ b/practice-areas/real-estate-construction/construction-law.html
@@ -25,8 +25,8 @@
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>

--- a/practice-areas/real-estate-construction/landlord-tenant-law.html
+++ b/practice-areas/real-estate-construction/landlord-tenant-law.html
@@ -25,8 +25,8 @@
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>

--- a/practice-areas/real-estate-construction/real-estate-law.html
+++ b/practice-areas/real-estate-construction/real-estate-law.html
@@ -25,8 +25,8 @@
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>

--- a/practice-areas/regulatory-compliance/administrative-law.html
+++ b/practice-areas/regulatory-compliance/administrative-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -97,36 +97,36 @@
      </li>
     </ul>
    </div>
- </header>
- <main id="main-content">
-  <section class="hero">
-   <div class="container">
-    <h1>
-     Administrative Law
-    </h1>
-    <p class="drop-cap">
-     Administrative agencies regulate many aspects of daily life. Effective representation demands familiarity with agency rules and the procedural steps that guide each decision.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     We help clients respond to investigations, file applications, and present evidence in administrative hearings. Careful attention to detail can streamline the process and lead to timely approvals.
-    </p>
-    <p>
-     When agency action adversely affects your rights, we pursue appeals and judicial review. Our advocacy focuses on building a record that clearly explains your position and the relief you seek.
-    </p>
-    <p>
-     Contact the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-    for guidance on agency matters.
-   </p>
-  </div>
- </section>
- </main>
+  </header>
+  <main id="main-content">
+   <section class="hero">
+    <div class="container">
+     <h1>
+      Administrative Law
+     </h1>
+     <p class="drop-cap">
+      Administrative agencies regulate many aspects of daily life. Effective representation demands familiarity with agency rules and the procedural steps that guide each decision.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      We help clients respond to investigations, file applications, and present evidence in administrative hearings. Careful attention to detail can streamline the process and lead to timely approvals.
+     </p>
+     <p>
+      When agency action adversely affects your rights, we pursue appeals and judicial review. Our advocacy focuses on building a record that clearly explains your position and the relief you seek.
+     </p>
+     <p>
+      Contact the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      for guidance on agency matters.
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>
@@ -164,5 +164,5 @@
   </footer>
   <script defer="" src="../../js/menu.js">
   </script>
-</body>
+ </body>
 </html>

--- a/practice-areas/regulatory-compliance/election-law.html
+++ b/practice-areas/regulatory-compliance/election-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -97,36 +97,36 @@
      </li>
     </ul>
    </div>
- </header>
- <main id="main-content">
-  <section class="hero">
-   <div class="container">
-    <h1>
-     Election Law
-    </h1>
-    <p class="drop-cap">
-     Elections must be conducted fairly and transparently. We counsel candidates and organizations on how to comply with complex rules governing campaigns and voting.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Our work includes advising on campaign finance limits, reporting obligations, and advertising regulations. We also assist with ballot initiatives and voter outreach strategies.
-    </p>
-    <p>
-     If disputes arise, we represent clients in recounts and contest proceedings. Swift action can preserve electoral rights and protect the integrity of results.
-    </p>
-    <p>
-     For election law guidance, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-    .
-   </p>
-  </div>
- </section>
- </main>
+  </header>
+  <main id="main-content">
+   <section class="hero">
+    <div class="container">
+     <h1>
+      Election Law
+     </h1>
+     <p class="drop-cap">
+      Elections must be conducted fairly and transparently. We counsel candidates and organizations on how to comply with complex rules governing campaigns and voting.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Our work includes advising on campaign finance limits, reporting obligations, and advertising regulations. We also assist with ballot initiatives and voter outreach strategies.
+     </p>
+     <p>
+      If disputes arise, we represent clients in recounts and contest proceedings. Swift action can preserve electoral rights and protect the integrity of results.
+     </p>
+     <p>
+      For election law guidance, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>
@@ -164,5 +164,5 @@
   </footer>
   <script defer="" src="../../js/menu.js">
   </script>
-</body>
+ </body>
 </html>

--- a/practice-areas/regulatory-compliance/environmental-natural-resources-law.html
+++ b/practice-areas/regulatory-compliance/environmental-natural-resources-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -97,36 +97,36 @@
      </li>
     </ul>
    </div>
- </header>
- <main id="main-content">
-  <section class="hero">
-   <div class="container">
-    <h1>
-     Environmental &amp; Natural Resources Law
-    </h1>
-    <p class="drop-cap">
-     Environmental regulations shape how property is developed and how resources are used. We help clients anticipate compliance challenges and manage them efficiently.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     Our services include advising on permits, remediation plans, and environmental impact reviews. Early guidance can minimize liability and prevent costly disputes.
-    </p>
-    <p>
-     When conflicts arise, we negotiate with regulators and opposing parties. If necessary, we litigate to protect your interests in land, water, and mineral rights.
-    </p>
-    <p>
-     To address environmental or natural resource concerns, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-    .
-   </p>
-  </div>
- </section>
- </main>
+  </header>
+  <main id="main-content">
+   <section class="hero">
+    <div class="container">
+     <h1>
+      Environmental &amp; Natural Resources Law
+     </h1>
+     <p class="drop-cap">
+      Environmental regulations shape how property is developed and how resources are used. We help clients anticipate compliance challenges and manage them efficiently.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      Our services include advising on permits, remediation plans, and environmental impact reviews. Early guidance can minimize liability and prevent costly disputes.
+     </p>
+     <p>
+      When conflicts arise, we negotiate with regulators and opposing parties. If necessary, we litigate to protect your interests in land, water, and mineral rights.
+     </p>
+     <p>
+      To address environmental or natural resource concerns, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      .
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>
@@ -164,5 +164,5 @@
   </footer>
   <script defer="" src="../../js/menu.js">
   </script>
-</body>
+ </body>
 </html>

--- a/practice-areas/regulatory-compliance/public-policy-government-affairs-law.html
+++ b/practice-areas/regulatory-compliance/public-policy-government-affairs-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -97,36 +97,40 @@
      </li>
     </ul>
    </div>
- </header>
- <main id="main-content">
-  <section class="hero">
-   <div class="container">
-    <h1>
-     Public Policy &amp; Government Affairs
-    </h1>
-    <p class="drop-cap">
-     Influencing policy requires a clear understanding of legislative processes and regulatory frameworks. Our firm helps clients communicate effectively with decision-makers.
-    </p>
-   </div>
-  </section>
-  <section class="alt">
-   <div class="container">
-    <p>
-     We monitor legislative developments and craft strategies to advance or oppose proposed measures. Whether drafting testimony or preparing briefing materials, we work to articulate your objectives.
-    </p>
-    <p>
-     Compliance with lobbying rules and reporting obligations is essential. We guide organizations through registration requirements and ethical considerations at the state and federal levels.
-    </p>
-    <p>
-     For assistance with government affairs, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . Follow us on Facebook at <a href="https://www.facebook.com/GabrielSmithAttorney/">Providing Justice 4U</a> to stay informed.
-    </p>
-   </div>
-  </section>
- </main>
+  </header>
+  <main id="main-content">
+   <section class="hero">
+    <div class="container">
+     <h1>
+      Public Policy &amp; Government Affairs
+     </h1>
+     <p class="drop-cap">
+      Influencing policy requires a clear understanding of legislative processes and regulatory frameworks. Our firm helps clients communicate effectively with decision-makers.
+     </p>
+    </div>
+   </section>
+   <section class="alt">
+    <div class="container">
+     <p>
+      We monitor legislative developments and craft strategies to advance or oppose proposed measures. Whether drafting testimony or preparing briefing materials, we work to articulate your objectives.
+     </p>
+     <p>
+      Compliance with lobbying rules and reporting obligations is essential. We guide organizations through registration requirements and ethical considerations at the state and federal levels.
+     </p>
+     <p>
+      For assistance with government affairs, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">
+       gabrieljoseph.smith@gmail.com
+      </a>
+      . Follow us on Facebook at
+      <a href="https://www.facebook.com/GabrielSmithAttorney/">
+       Providing Justice 4U
+      </a>
+      to stay informed.
+     </p>
+    </div>
+   </section>
+  </main>
   <footer class="footer">
    <div class="container">
     <p>
@@ -164,5 +168,5 @@
   </footer>
   <script defer="" src="../../js/menu.js">
   </script>
-</body>
+ </body>
 </html>

--- a/practice-areas/sports-entertainment/entertainment-sports-law.html
+++ b/practice-areas/sports-entertainment/entertainment-sports-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -115,7 +115,10 @@
     </p>
     <p>
      Located in Opelika, Alabama, the Law Office of Gabriel Smith LLC is ready to represent entertainers and athletes throughout the region. Contact us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> for assistance.
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     for assistance.
     </p>
    </div>
   </section>

--- a/practice-areas/sports-entertainment/gaming-law.html
+++ b/practice-areas/sports-entertainment/gaming-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -115,7 +115,10 @@
     </p>
     <p>
      For tailored advice on gaming ventures, reach the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     .
     </p>
    </div>
   </section>

--- a/practice-areas/sports-entertainment/sports-law.html
+++ b/practice-areas/sports-entertainment/sports-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -115,7 +115,10 @@
     </p>
     <p>
      The Law Office of Gabriel Smith LLC serves clients across Alabama from our Opelika office. For advice on sports-related matters, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     .
     </p>
    </div>
   </section>

--- a/practice-areas/technology-data-privacy/cybersecurity-data-privacy-law.html
+++ b/practice-areas/technology-data-privacy/cybersecurity-data-privacy-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/technology-data-privacy/internet-ecommerce-law.html
+++ b/practice-areas/technology-data-privacy/internet-ecommerce-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/technology-data-privacy/technology-law.html
+++ b/practice-areas/technology-data-privacy/technology-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/technology-data-privacy/telecommunications-law.html
+++ b/practice-areas/technology-data-privacy/telecommunications-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -124,7 +124,11 @@
   </section>
   <section class="back-to-top-section">
    <div class="container">
-    <p class="back-to-top"><a href="#hero">Back to top</a></p>
+    <p class="back-to-top">
+     <a href="#hero">
+      Back to top
+     </a>
+    </p>
    </div>
   </section>
   <footer class="footer">

--- a/practice-areas/transportation-maritime/admiralty-maritime-law.html
+++ b/practice-areas/transportation-maritime/admiralty-maritime-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -115,7 +115,10 @@
     </p>
     <p>
      Based in Opelika, Alabama, the Law Office of Gabriel Smith LLC offers prompt assistance throughout the Gulf Coast region. For counsel on maritime matters, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     .
     </p>
    </div>
   </section>

--- a/practice-areas/transportation-maritime/aviation-law.html
+++ b/practice-areas/transportation-maritime/aviation-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -115,7 +115,10 @@
     </p>
     <p>
      If you face an aviation dispute or need guidance on compliance, the Law Office of Gabriel Smith LLC in Opelika stands ready to help. Reach us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     .
     </p>
    </div>
   </section>

--- a/practice-areas/transportation-maritime/railroad-transportation-law.html
+++ b/practice-areas/transportation-maritime/railroad-transportation-law.html
@@ -34,11 +34,11 @@
   <!-- Twitter Card Meta Tags -->
   <!-- Robots and Indexing -->
   <!-- Stylesheets -->
-  <link href="../../css/style.css" rel="stylesheet"/>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <header>
@@ -115,7 +115,10 @@
     </p>
     <p>
      Clients throughout Alabama can rely on the Law Office of Gabriel Smith LLC for guidance on rail and transportation matters. Contact us at (334) 750-1729 or via email at
-     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
+     <a href="mailto:gabrieljoseph.smith@gmail.com">
+      gabrieljoseph.smith@gmail.com
+     </a>
+     .
     </p>
    </div>
   </section>


### PR DESCRIPTION
## Summary
- move Google Fonts and Font Awesome links before the main stylesheet on every practice area page for SEO & design parity

## Testing
- `python3 reorder_assets.py` *(tooling)*

------
https://chatgpt.com/codex/tasks/task_e_6874cfae58b4832188d94c73fbebd1be