### PR TITLE
Add SEO sections to corporate and IP practice pages

### DIFF
--- a/practice-areas/corporate-business/corporate-law.html
+++ b/practice-areas/corporate-business/corporate-law.html
@@ -111,24 +111,30 @@
    </section>
    <section class="alt">
     <div class="container">
+     <h2>Forming Your Business</h2>
+     <h3>Sound Business Foundations</h3>
      <p>
-      Corporations operate within a complex regulatory framework. At the formation stage, we help clients choose suitable entity structures and complete required filings. Careful documentation at the outset builds a solid legal foundation.
+      Choosing the right structure shapes liability and tax obligations. We guide new owners through articles of incorporation and initial filings so operations begin on solid ground.
      </p>
      <p>
-      Once a company is organized, directors and officers must observe formalities that preserve limited liability. We counsel leadership on fiduciary duties, meeting protocols, and recordkeeping. Sound governance reassures investors and reduces risk.
+      With careful planning, a company can attract investors and streamline governance from day one. This preparation supports long term stability.
+     </p>
+     <h2>Corporate Compliance</h2>
+     <h3>Guidance for Directors and Officers</h3>
+     <p>
+      Alabama corporations must maintain minutes, issue shares properly, and document major decisions. We work closely with leadership to meet these standards.
      </p>
      <p>
-      Operational matters often demand precise contracts. We prepare bylaws, shareholder agreements, vendor arrangements, and employment policies while monitoring both state and federal regulations to keep your business compliant.
+      Ongoing compliance builds confidence among stakeholders and reduces the risk of disputes. Our counsel covers fiduciary duties, regulatory filings, and board procedures.
+     </p>
+     <h2>Contracts and Ongoing Counsel</h2>
+     <h3>Protecting Your Long Term Interests</h3>
+     <p>
+      Precise contracts safeguard rights in dealings with suppliers, partners, and employees. We draft agreements that reflect your goals and protect trade secrets.
      </p>
      <p>
-      Whether guiding a start-up or an established enterprise, we provide strategic advice that supports growth and guards against disputes. Each solution is tailored to your objectives and the unique challenges of your industry.
-     </p>
-     <p>
-      For guidance on corporate governance or transactions, call (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      for more information.
+      As operations evolve, we review policies and advise on transactions so you can focus on growth. For guidance on corporate matters, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
      </p>
     </div>
    </section>

--- a/practice-areas/corporate-business/franchise-law.html
+++ b/practice-areas/corporate-business/franchise-law.html
@@ -111,17 +111,30 @@
    </section>
    <section class="alt">
     <div class="container">
+     <h2>Launching a Franchise</h2>
+     <h3>Documents and Disclosure</h3>
      <p>
-      Franchising enables growth by licensing a proven business model. We prepare franchise disclosure documents and register them where required, providing transparency for potential franchisees.
+      Franchising allows a proven concept to grow through third party investment. We prepare the franchise disclosure document and handle registration where required.
      </p>
      <p>
-      A well-crafted franchise agreement sets expectations for trademark use, territory protection, fees, and operational standards. Our office customizes these agreements so franchisors and franchisees understand their respective obligations.
+      Clear disclosures build trust with potential franchisees and set expectations about fees, training, and system standards.
+     </p>
+     <h2>Franchise Agreements</h2>
+     <h3>Defining Rights and Obligations</h3>
+     <p>
+      A carefully drafted agreement addresses territory, branding, and operational procedures.
      </p>
      <p>
-      Ongoing compliance is vital. We advise on licensing, employment, and advertising rules so each location operates within the law while maintaining consistent quality.
+      By tailoring these contracts, we help both franchisors and franchisees understand their duties and minimize conflicts.
+     </p>
+     <h2>Ongoing Compliance</h2>
+     <h3>Protecting the Brand</h3>
+     <p>
+      State and federal rules govern advertising, employment, and licensing. We advise on updates so each location remains consistent and law compliant.
      </p>
      <p>
-      Whether establishing a new franchise system or buying an existing unit, we offer practical guidance on renewals and dispute resolution, helping protect the brand and investment over time.
+      For guidance on franchising in Alabama, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
      </p>
     </div>
    </section>

--- a/practice-areas/corporate-business/mergers-acquisitions-law.html
+++ b/practice-areas/corporate-business/mergers-acquisitions-law.html
@@ -111,24 +111,30 @@
    </section>
    <section class="alt">
     <div class="container">
+     <h2>Planning a Transaction</h2>
+     <h3>Due Diligence and Strategy</h3>
      <p>
-      Mergers and acquisitions require careful preparation. We begin with thorough due diligence to uncover financial obligations, regulatory concerns, and potential liabilities. This insight guides negotiations and helps structure a sound deal.
+      Successful mergers and acquisitions begin with a careful review of assets and liabilities. We examine financial statements, contracts, and regulatory filings to build a clear picture.
      </p>
      <p>
-      When drafting definitive agreements, we safeguard our clients' interests through precise representations, warranties, and indemnities. We address federal and state requirements so each transaction satisfies legal standards and meets strategic objectives.
+      This groundwork shapes negotiations and ensures that each party understands the risks and opportunities before moving forward.
+     </p>
+     <h2>Negotiating the Deal</h2>
+     <h3>Protecting Your Investment</h3>
+     <p>
+      During negotiations we draft terms that align with your objectives and comply with Alabama and federal law.
      </p>
      <p>
-      Some industries demand government approval before closing. We coordinate regulatory filings and shareholder communications to keep the process on schedule and minimize post-closing exposure.
+      Our firm prepares representations and warranties that guard against hidden issues, balancing legal obligations with your business strategy.
+     </p>
+     <h2>Closing and Integration</h2>
+     <h3>Maintaining Momentum</h3>
+     <p>
+      We coordinate filings and communications so that transactions close on schedule. Post closing, we assist with integrating operations to reduce disruption.
      </p>
      <p>
-      From negotiation to final integration, our firm manages the details so your organization can focus on growth. We work to deliver transactions that advance your business while minimizing disruption.
-     </p>
-     <p>
-      If you need skilled counsel for a merger or acquisition, call (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
+      To discuss your plans, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
      </p>
     </div>
    </section>

--- a/practice-areas/corporate-business/venture-capital-law.html
+++ b/practice-areas/corporate-business/venture-capital-law.html
@@ -111,24 +111,30 @@
    </section>
    <section class="alt">
     <div class="container">
+     <h2>Preparing for Investors</h2>
+     <h3>Structuring Early Funding</h3>
      <p>
-      Securing venture capital involves more than attracting investors. We assist startups in drafting clear business plans and preparing accurate disclosures so they can present opportunities effectively and legally.
+      Attracting venture capital begins with a clear business model and accurate disclosures. We help founders create plans that highlight potential while meeting legal requirements.
      </p>
      <p>
-      Investment agreements dictate governance and economic rights. Our office drafts terms for preferred shares, board composition, and liquidation preferences, balancing investors' demands with founders' long-term vision.
+      Early preparation lays the groundwork for smooth negotiations and demonstrates professionalism to prospective investors.
+     </p>
+     <h2>Term Sheets and Agreements</h2>
+     <h3>Balancing Rights and Returns</h3>
+     <p>
+      We negotiate term sheets that set expectations for valuation, board seats, and liquidation preferences.
      </p>
      <p>
-      Ongoing regulatory obligations cannot be ignored once funding is secured. We help maintain cap tables, craft policies, and satisfy reporting requirements that instill confidence in future investors and regulators alike.
+      Our agreements address voting rights and protective provisions so both founders and investors understand their roles.
      </p>
+     <h2>Regulatory Compliance</h2>
+     <h3>Building Trust with Stakeholders</h3>
      <p>
-      With sound legal advice, emerging companies can raise capital without sacrificing control. We work to forge durable relationships between investors and founders, positioning businesses for sustainable growth.
+      Funding rounds involve securities rules and ongoing reporting. We manage filings and maintain cap tables to satisfy investors and regulators.
      </p>
      <p>
       To discuss your fundraising goals, call (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
+      <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
      </p>
     </div>
    </section>

--- a/practice-areas/intellectual-property/copyright-law.html
+++ b/practice-areas/intellectual-property/copyright-law.html
@@ -108,18 +108,30 @@
    </section>
    <section class="alt">
     <div class="container">
+     <h2>Registering Creative Works</h2>
+     <h3>Building Proof of Ownership</h3>
      <p>
-      Registration is the strongest step toward enforcing your rights. We prepare filings, advise on ownership questions, and monitor deadlines so that your work remains secure.
+      Federal registration provides a public record of your authorship.
      </p>
      <p>
-      Should infringement occur, our firm acts quickly with notices, negotiations, and litigation when necessary. We aim to stop unauthorized use while preserving your reputation.
+      We handle applications and monitor deadlines so your work is ready for enforcement.
+     </p>
+     <h2>Enforcing Your Rights</h2>
+     <h3>Stopping Unauthorized Use</h3>
+     <p>
+      When infringement occurs, we send notices and negotiate solutions.
      </p>
      <p>
-      For copyright guidance, reach the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      . Your creativity deserves diligent protection.
+      Litigation may be necessary to recover damages and deter further violations.
+     </p>
+     <h2>Leveraging Copyrights</h2>
+     <h3>Adding Value Through Licensing</h3>
+     <p>
+      Licensing agreements generate revenue while preserving control.
+     </p>
+     <p>
+      For guidance on copyrights, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
      </p>
     </div>
    </section>

--- a/practice-areas/intellectual-property/intellectual-property-law.html
+++ b/practice-areas/intellectual-property/intellectual-property-law.html
@@ -108,22 +108,30 @@
    </section>
    <section class="alt">
     <div class="container">
+     <h2>Patents and Trade Secrets</h2>
+     <h3>Safeguarding Innovations</h3>
      <p>
-      From patents and trademarks to copyrights and trade secrets, we analyze which protections best serve your goals. By preparing thorough applications and maintaining clear documentation, we help secure lasting value from your creations.
+      Patents and trade secrets protect technical solutions and confidential processes. We prepare applications and confidentiality plans to secure these assets.
      </p>
      <p>
-      We counsel on licensing, technology transfers, and enforcement actions when infringement threatens your position in the market. Our guidance blends legal skill with practical insight to preserve competitive advantages.
+      Thorough documentation and timely filings help you maintain a competitive edge and attract investment.
+     </p>
+     <h2>Trademarks and Branding</h2>
+     <h3>Securing Distinct Identity</h3>
+     <p>
+      Clear branding distinguishes your goods and services in the market. We file trademark applications and monitor for possible conflicts.
      </p>
      <p>
-      To discuss intellectual property strategies, contact the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      . Connect on Facebook at
-      <a href="https://www.facebook.com/GabrielSmithAttorney/">
-       Providing Justice 4U
-      </a>
-      for updates.
+      Registration strengthens your position when enforcing rights against imitators.
+     </p>
+     <h2>Licensing and Enforcement</h2>
+     <h3>Keeping Your Advantage</h3>
+     <p>
+      Our firm drafts licensing agreements that generate revenue while preserving ownership.
+     </p>
+     <p>
+      When disputes arise, we pursue settlements or litigation. To discuss intellectual property strategies, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
      </p>
     </div>
    </section>

--- a/practice-areas/intellectual-property/trademark-law.html
+++ b/practice-areas/intellectual-property/trademark-law.html
@@ -108,18 +108,30 @@
    </section>
    <section class="alt">
     <div class="container">
+     <h2>Selecting a Strong Mark</h2>
+     <h3>Search and Clearance</h3>
      <p>
-      We conduct thorough searches to assess the availability of your mark and prepare applications that meet federal requirements. Our firm also monitors renewals and advises on international filings when expansion is planned.
+      A distinctive mark sets your business apart. We conduct searches to ensure the name or logo is available before you invest in branding.
      </p>
      <p>
-      If another business adopts a confusingly similar name or logo, we evaluate the impact on your reputation and pursue solutions ranging from settlement to litigation.
+      Clearance reduces the likelihood of disputes and prevents wasted marketing costs.
+     </p>
+     <h2>Registration Process</h2>
+     <h3>Protecting Your Brand</h3>
+     <p>
+      We prepare federal trademark applications and respond to office actions to secure your registration.
      </p>
      <p>
-      For guidance on protecting your brand, contact the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
+      International filings may be appropriate when expansion is planned.
+     </p>
+     <h2>Maintaining and Defending</h2>
+     <h3>Managing Renewals and Disputes</h3>
+     <p>
+      Trademarks require maintenance filings to remain in force. We track deadlines and handle renewals.
+     </p>
+     <p>
+      If another party uses a confusingly similar mark, we pursue negotiations or litigation. For assistance, call (334) 750-1729 or email
+      <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
      </p>
     </div>
    </section>


### PR DESCRIPTION
## Summary
- add section headers, subheaders, and SEO text to corporate and intellectual property pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874d72e51088321abef0ba160e6900a