### PR TITLE
Add SEO sections to labor and healthcare pages

### DIFF
--- a/practice-areas/healthcare-life-sciences/biotechnology-life-sciences-law.html
+++ b/practice-areas/healthcare-life-sciences/biotechnology-life-sciences-law.html
@@ -108,37 +108,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section class="alt">
-    <div class="container">
-     <p>
-      Our firm helps laboratories, start-ups, and established companies secure patents and safeguard proprietary technology. Effective intellectual property strategies encourage investment and allow new discoveries to reach the market.
-     </p>
-     <p>
-      We counsel clients on compliance with federal regulations governing human and animal research, including Institutional Review Board requirements. Adhering to these rules is essential for ethical investigations and future commercialization.
-     </p>
-     <p>
-      Collaborations with universities, hospitals, and investors require careful contract drafting. We assist with licensing agreements, joint development projects, and technology transfers to ensure rights are clearly defined.
-     </p>
-     <p>
-      To discuss the legal framework surrounding your life sciences venture, contact us at (334) 750-1729 or
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
-     </p>
-    </div>
-   </section>
-   <section class="back-to-top-section">
-    <div class="container">
-     <p class="back-to-top">
-      <a href="#hero">
-       Back to top
-      </a>
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section class="alt">
+   <div class="container">
+    <h2>Intellectual Property</h2>
+    <h3>Safeguarding Innovation</h3>
+    <p>
+     Patents and trade secrets help protect discoveries in biotechnology. Securing these rights encourages investment and attracts partners.
+    </p>
+    <p>
+     Gabriel Smith assists start ups and research teams with patent filings and confidentiality agreements.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Research Compliance</h2>
+    <h3>Meeting Federal Standards</h3>
+    <p>
+     Laboratories conducting human or animal studies must follow Institutional Review Board protocols and other regulations.
+    </p>
+    <p>
+     Adhering to these requirements promotes ethical investigations and paves the way for commercialization.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Collaborative Agreements</h2>
+    <h3>Navigating Joint Ventures</h3>
+    <p>
+     Partnerships with universities, hospitals, and investors require clear contracts outlining each party’s role.
+    </p>
+    <p>
+     For guidance on technology transfers or licensing, call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     .
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/healthcare-life-sciences/healthcare-law.html
+++ b/practice-areas/healthcare-life-sciences/healthcare-law.html
@@ -108,37 +108,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section class="alt">
-    <div class="container">
-     <p>
-      Our firm advises hospitals, clinics, and individual practitioners on compliance with statutes such as the Health Insurance Portability and Accountability Act and the Stark Law. Guidance covers billing practices, privacy obligations, and relationships with referral sources.
-     </p>
-     <p>
-      We assist with licensing, certification, and the contractual matters that arise in transactions, including practice acquisitions and joint ventures. Proper structuring protects both financial interests and regulatory standing.
-     </p>
-     <p>
-      When disputes occur, we represent health care professionals before administrative boards and in court. Whether the issue involves reimbursement, credentialing, or disciplinary proceedings, we work to safeguard your ability to serve patients.
-     </p>
-     <p>
-      For counsel tailored to your health care practice, call (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      . We stand ready to help you navigate this demanding area of law.
-     </p>
-    </div>
-   </section>
-   <section class="back-to-top-section">
-    <div class="container">
-     <p class="back-to-top">
-      <a href="#hero">
-       Back to top
-      </a>
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section class="alt">
+   <div class="container">
+    <h2>Regulatory Compliance</h2>
+    <h3>HIPAA and Stark Law</h3>
+    <p>
+     Health care providers operate under strict privacy and referral rules. Observing the Health Insurance Portability and Accountability Act and the Stark Law keeps patient information secure and business relationships transparent.
+    </p>
+    <p>
+     Gabriel Smith advises hospitals and clinics in Opelika on best practices for documentation and billing so that services meet state and federal standards.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Licensing Issues</h2>
+    <h3>Maintaining Credentials</h3>
+    <p>
+     Practitioners must stay current with professional licensing boards. Renewals, continuing education, and timely reporting of any disciplinary matters help avoid interruptions in patient care.
+    </p>
+    <p>
+     Gabriel assists health professionals with board applications, responses to complaints, and other administrative concerns.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Facility Transactions</h2>
+    <h3>Structuring Agreements</h3>
+    <p>
+     Mergers, acquisitions, and joint ventures require careful contract drafting to protect regulatory compliance and financial goals.
+    </p>
+    <p>
+     For advice tailored to your practice, call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     .
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/healthcare-life-sciences/medical-malpractice-law.html
+++ b/practice-areas/healthcare-life-sciences/medical-malpractice-law.html
@@ -108,37 +108,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section class="alt">
-    <div class="container">
-     <p>
-      We review medical records, consult qualified experts, and evaluate whether a provider's conduct fell short of accepted practice. Identifying the proper defendants and potential theories of liability is critical at the outset.
-     </p>
-     <p>
-      Once a claim is established, we pursue negotiation or litigation to secure payment for medical expenses, lost wages, and other damages. Our firm represents both injured patients and medical professionals, giving us a well-rounded understanding of procedural requirements.
-     </p>
-     <p>
-      Medical malpractice suits require strict adherence to filing deadlines and evidentiary rules. We manage these complexities while working toward a resolution that holds negligent parties accountable or defends against unfounded allegations.
-     </p>
-     <p>
-      If you have questions about a potential malpractice claim, call (334) 750-1729 or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      to arrange a consultation.
-     </p>
-    </div>
-   </section>
-   <section class="back-to-top-section">
-    <div class="container">
-     <p class="back-to-top">
-      <a href="#hero">
-       Back to top
-      </a>
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section class="alt">
+   <div class="container">
+    <h2>Establishing Negligence</h2>
+    <h3>Reviewing Medical Records</h3>
+    <p>
+     Determining whether a provider failed to meet accepted standards requires careful analysis of treatment notes and expert opinions.
+    </p>
+    <p>
+     Gabriel Smith works with medical specialists to evaluate potential claims and identify responsible parties.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Damages and Compensation</h2>
+    <h3>Recovery for Patients</h3>
+    <p>
+     Injured individuals may seek payment for additional treatment, lost earnings, and other losses caused by substandard care.
+    </p>
+    <p>
+     Our firm negotiates settlements and, when necessary, pursues litigation to secure appropriate compensation.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Defense Strategies</h2>
+    <h3>Protecting Professionals</h3>
+    <p>
+     Medical providers facing allegations require a thorough response backed by expert testimony and a clear record of treatment decisions.
+    </p>
+    <p>
+     To discuss a potential malpractice matter, call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     .
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/healthcare-life-sciences/pharmaceutical-medical-device-law.html
+++ b/practice-areas/healthcare-life-sciences/pharmaceutical-medical-device-law.html
@@ -108,37 +108,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section class="alt">
-    <div class="container">
-     <p>
-      We advise on every stage of bringing a therapy or device to market, from preclinical research through FDA submission. Our services include preparing regulatory filings and addressing agency questions.
-     </p>
-     <p>
-      Marketing and distribution carry their own requirements. We help ensure promotional materials, labeling, and distribution agreements meet federal standards and minimize enforcement actions.
-     </p>
-     <p>
-      When disputes arise, we defend clients in product liability suits and government investigations. Timely action can limit financial exposure and protect a company's reputation.
-     </p>
-     <p>
-      For guidance in this highly regulated industry, reach us at (334) 750-1729 or
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
-     </p>
-    </div>
-   </section>
-   <section class="back-to-top-section">
-    <div class="container">
-     <p class="back-to-top">
-      <a href="#hero">
-       Back to top
-      </a>
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section class="alt">
+   <div class="container">
+    <h2>Regulatory Approval</h2>
+    <h3>Working with the FDA</h3>
+    <p>
+     Bringing a therapy or device to market requires extensive testing and submission of detailed data to federal regulators.
+    </p>
+    <p>
+     Gabriel Smith assists companies in preparing filings and responding to agency inquiries throughout the approval process.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Marketing Rules</h2>
+    <h3>Advertising and Labeling</h3>
+    <p>
+     Once products are cleared, promotional materials and distribution agreements must comply with federal standards.
+    </p>
+    <p>
+     Careful review of labels and marketing campaigns helps prevent enforcement actions that could delay sales.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Litigation Defense</h2>
+    <h3>Addressing Product Claims</h3>
+    <p>
+     Manufacturers may face lawsuits or investigations when side effects arise. Timely action can protect finances and reputation.
+    </p>
+    <p>
+     For guidance in this regulated field, call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     .
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/discrimination-law.html
+++ b/practice-areas/labor-employment/discrimination-law.html
@@ -95,32 +95,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section>
-    <div class="container">
-     <p>
-      The Equal Employment Opportunity Commission enforces statutes such as Title VII and the Americans with Disabilities Act. Claims often begin with a charge filed through the EEOC, followed by investigation and potential litigation. Strict deadlines apply, making prompt consultation vital.
-     </p>
-     <p>
-      Evidence in discrimination cases may include personnel records, witness statements, and patterns of unequal treatment. Document preservation is crucial for both sides, as is a thorough understanding of the employer’s policies and practices.
-     </p>
-     <p>
-      Employers who foster inclusive workplaces benefit from reduced turnover and improved morale. Training and clear reporting procedures help prevent misconduct before it becomes an expensive lawsuit.
-     </p>
-     <p>
-      For advice on discrimination issues, reach me at
-      <a href="tel:+13347501729">
-       (334) 750-1729
-      </a>
-      or
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section>
+   <div class="container">
+    <h2>Protected Rights</h2>
+    <h3>Understanding Anti-Discrimination Laws</h3>
+    <p>
+     Federal statutes such as Title VII, the Americans with Disabilities Act, and the Age Discrimination in Employment Act safeguard workers from unfair treatment. Alabama follows these principles while also providing state remedies.
+    </p>
+    <p>
+     Gabriel Smith guides employees and businesses in Opelika through these overlapping rules so that hiring and promotion decisions remain lawful and transparent.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Investigation and Filing</h2>
+    <h3>The EEOC Process</h3>
+    <p>
+     Discrimination claims often begin with a charge filed with the Equal Employment Opportunity Commission. The agency reviews the facts, may investigate, and can issue a right to sue letter if settlement efforts fail.
+    </p>
+    <p>
+     Because strict deadlines apply, timely consultation helps preserve valuable evidence and positions clients for the best outcome.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Remedies for Victims</h2>
+    <h3>Securing Relief</h3>
+    <p>
+     Successful discrimination claims may lead to reinstatement, back pay, or other monetary damages. Courts can also order policy changes to prevent further violations.
+    </p>
+    <p>
+     For personalized guidance on these matters, call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     .
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/erisa-employee-benefits-law.html
+++ b/practice-areas/labor-employment/erisa-employee-benefits-law.html
@@ -95,32 +95,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section>
-    <div class="container">
-     <p>
-      ERISA sets standards for pension and health plans in private industry. It requires transparency in plan administration and fiduciary responsibility from those managing funds. Compliance mistakes can lead to heavy penalties and jeopardize tax advantages.
-     </p>
-     <p>
-      Participants may bring claims for denied benefits or breaches of fiduciary duty. These cases often hinge on careful review of plan documents and the administrative record, as courts typically defer to the plan’s written terms.
-     </p>
-     <p>
-      Employers must keep plan documents current and notify employees of any changes. Proper reporting to the Department of Labor and the Internal Revenue Service helps maintain the plan’s qualified status.
-     </p>
-     <p>
-      If you have questions about a benefits plan, please call
-      <a href="tel:+13347501729">
-       (334) 750-1729
-      </a>
-      or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section>
+   <div class="container">
+    <h2>Plan Compliance</h2>
+    <h3>Meeting ERISA Requirements</h3>
+    <p>
+     The Employee Retirement Income Security Act governs pension and health plans for private employers. Proper documentation and fiduciary oversight protect both participants and plan sponsors.
+    </p>
+    <p>
+     Gabriel Smith works with Opelika businesses to keep their benefit programs in line with federal mandates while preserving valuable tax advantages.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Claims and Appeals</h2>
+    <h3>Helping Participants</h3>
+    <p>
+     Denied benefits or breaches of fiduciary duty can lead to complex disputes. Success often depends on a thorough review of plan terms and timely pursuit of administrative remedies.
+    </p>
+    <p>
+     Gabriel guides employees through these steps and, when necessary, litigates in federal court to enforce their rights.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Employer Responsibilities</h2>
+    <h3>Maintaining Qualified Status</h3>
+    <p>
+     Sponsors must update plan documents and provide regular notices to participants. Reporting to the Department of Labor and the Internal Revenue Service keeps the plan in good standing.
+    </p>
+    <p>
+     For questions about employee benefits, call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     .
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/labor-employment-law.html
+++ b/practice-areas/labor-employment/labor-employment-law.html
@@ -95,32 +95,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section>
-    <div class="container">
-     <p>
-      Labor and employment law covers hiring, workplace policies, and termination. Employers must comply with statutes such as the Fair Labor Standards Act and the Family and Medical Leave Act, while workers are entitled to fair wages and safe conditions. Each case demands an analysis of contracts and company practices.
-     </p>
-     <p>
-      Disputes may involve wrongful termination, wage claims, or labor union matters. Timely investigation and a clear strategy often prevent small issues from escalating into costly litigation. When negotiation fails, I provide assertive advocacy in state or federal court.
-     </p>
-     <p>
-      Employee handbooks and training programs help organizations maintain consistent standards. Crafting these documents carefully reduces risk and fosters a respectful workplace.
-     </p>
-     <p>
-      For assistance with any employment concern, call
-      <a href="tel:+13347501729">
-       (334) 750-1729
-      </a>
-      or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section>
+   <div class="container">
+    <h2>Workplace Standards</h2>
+    <h3>Federal and Alabama Rules</h3>
+    <p>
+     Employment regulations blend nationwide statutes with provisions unique to Alabama. Compliance with the Fair Labor Standards Act sets minimum wage and overtime requirements while state policies address hiring practices and meal breaks.
+    </p>
+    <p>
+     Gabriel Smith advises Opelika employers and workers on these rules so that offices and job sites operate smoothly. Clear understanding reduces conflicts and promotes productivity.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Contract Negotiations</h2>
+    <h3>Protecting Employers and Employees</h3>
+    <p>
+     Employment agreements outline the rights and responsibilities of both parties. Noncompete clauses, confidentiality terms, and severance packages must be drafted carefully to stand up in court.
+    </p>
+    <p>
+     By reviewing or negotiating these contracts, Gabriel helps clients safeguard their interests while complying with Alabama law. Precise language prevents confusion should disagreements arise later.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Resolving Disputes</h2>
+    <h3>Representation in Court and Before Agencies</h3>
+    <p>
+     Conflicts sometimes develop despite well crafted policies. Early intervention can lead to settlements that preserve working relationships and avoid lengthy proceedings.
+    </p>
+    <p>
+     When litigation becomes necessary, Gabriel represents clients before state agencies and in court. Call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     for guidance.
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/workers-compensation-law.html
+++ b/practice-areas/labor-employment/workers-compensation-law.html
@@ -95,32 +95,55 @@
     </p>
    </div>
   </section>
-  <main id="main-content">
-   <section>
-    <div class="container">
-     <p>
-      Workers compensation provides medical coverage and wage replacement for employees hurt in the course of employment. Employers must carry insurance or qualify as self-insured. Claims require prompt notice and documentation of the injury.
-     </p>
-     <p>
-      Disputes arise when insurers contest the severity of an injury or the connection to work. Hearings before the Alabama Department of Labor may be necessary to determine eligibility. An experienced attorney can gather medical evidence and present a clear case for benefits.
-     </p>
-     <p>
-      Some injuries also implicate third-party liability, such as defective machinery or negligent subcontractors. Exploring these avenues can lead to additional compensation beyond the workers compensation system.
-     </p>
-     <p>
-      To discuss an on-the-job injury, call
-      <a href="tel:+13347501729">
-       (334) 750-1729
-      </a>
-      or email
-      <a href="mailto:gabrieljoseph.smith@gmail.com">
-       gabrieljoseph.smith@gmail.com
-      </a>
-      .
-     </p>
-    </div>
-   </section>
-  </main>
+ <main id="main-content">
+  <section>
+   <div class="container">
+    <h2>Filing Claims</h2>
+    <h3>Prompt Notice and Documentation</h3>
+    <p>
+     Alabama law requires injured workers to notify their employer quickly after an accident. Timely reports and accurate medical records support a strong claim for benefits.
+    </p>
+    <p>
+     Gabriel Smith assists employees in gathering the necessary paperwork and submitting it to insurers or self insured employers.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Benefit Disputes</h2>
+    <h3>Administrative Hearings</h3>
+    <p>
+     Insurers sometimes dispute the extent of injuries or the connection to work duties. Hearings before the Alabama Department of Labor may be needed to resolve disagreements.
+    </p>
+    <p>
+     Careful presentation of medical evidence helps demonstrate the impact of the injury and the need for compensation.
+    </p>
+   </div>
+  </section>
+  <section>
+   <div class="container">
+    <h2>Third Party Actions</h2>
+    <h3>Exploring Additional Recovery</h3>
+    <p>
+     Injuries caused by faulty equipment or negligent subcontractors may allow lawsuits beyond the workers compensation system.
+    </p>
+    <p>
+     To discuss your options, call
+     <a href="tel:+13347501729">(334) 750-1729</a>
+     or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     .
+    </p>
+   </div>
+  </section>
+  <section class="back-to-top-section">
+   <div class="container">
+    <p class="back-to-top">
+     <a href="#hero">Back to top</a>
+    </p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>


### PR DESCRIPTION
## Summary
- rewrite labor and employment practice pages with three SEO-friendly sections each
- expand healthcare practice pages with structured headers and paragraphs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d74bc0d48321a1db01316eee7672