### PR TITLE
Add SEO sectioned copy for finance & tech practice areas

### DIFF
--- a/practice-areas/finance-services/banking-finance-law.html
+++ b/practice-areas/finance-services/banking-finance-law.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     Banking regulations operate on state and federal levels. We interpret statutes governing deposits, lending practices, and secured transactions, drafting agreements that meet those requirements while promoting clarity.
-    </p>
-    <p>
-     Disputes in the finance sector demand quick resolution. Whether negotiating workout agreements or litigating creditor claims, we work to protect your financial position and safeguard important collateral.
-    </p>
-    <p>
-     For guidance on complex loans and regulatory compliance, contact us at (334) 750-1729 or by email at
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . We serve clients throughout Alabama from our office in Opelika.
-    </p>
+    <h2>Commercial Lending</h2>
+    <h3>Structuring secure transactions</h3>
+    <p>We counsel lenders and borrowers on loan documentation and collateral arrangements. Careful planning helps safeguard assets and reduce the chance of disputes.</p>
+    <p>Gabriel Smith, an Alabama attorney based in Opelika, drafts financing agreements that reflect each party's objectives while satisfying legal requirements.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Regulatory Compliance</h2>
+    <h3>Navigating oversight at every level</h3>
+    <p>Financial institutions must comply with both state and federal rules. We monitor regulatory updates so that each transaction aligns with current standards.</p>
+    <p>Our firm guides clients through licensing, reporting obligations and examinations to keep operations running smoothly.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Resolving Disputes</h2>
+    <h3>Protecting assets and relationships</h3>
+    <p>When disagreements arise over loans or security interests we pursue practical solutions including workouts and litigation when necessary.</p>
+    <p>For assistance call (334) 750-1729 or email <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>. We serve clients across Alabama from our Opelika office.</p>
    </div>
   </section>
   <section class="back-to-top-section">

--- a/practice-areas/finance-services/bankruptcy-law.html
+++ b/practice-areas/finance-services/bankruptcy-law.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     We evaluate each situation to determine whether liquidation or reorganization best serves the client's objectives. By preparing petitions, schedules, and plans with care, we position clients to navigate court procedures effectively.
-    </p>
-    <p>
-     Creditors rely on counsel to assert their rights in bankruptcy court. Our firm prepares proofs of claim, monitors plan confirmation, and pursues relief from the automatic stay when warranted.
-    </p>
-    <p>
-     For help with bankruptcy matters, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     . We offer pragmatic solutions to complex financial problems.
-    </p>
+    <h2>Chapter 7 and Chapter 11</h2>
+    <h3>Choosing the right path</h3>
+    <p>We review each client's situation to determine whether liquidation or reorganization offers the best resolution.</p>
+    <p>Gabriel Smith prepares petitions and schedules with precision so that proceedings move forward efficiently.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Creditor Representation</h2>
+    <h3>Protecting financial interests</h3>
+    <p>Creditors rely on experienced counsel to assert their rights. Our firm files proofs of claim and seeks relief from the automatic stay when needed.</p>
+    <p>Monitoring plan confirmation ensures that secured and unsecured creditors receive proper treatment.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Local Counsel in Opelika</h2>
+    <h3>Guidance through difficult times</h3>
+    <p>Bankruptcy can be complex, but clear advice helps you make informed decisions about debt relief.</p>
+    <p>For assistance contact our office at (334) 750-1729 or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>. Gabriel Smith serves clients across Alabama.</p>
    </div>
   </section>
   <section class="back-to-top-section">

--- a/practice-areas/finance-services/capital-markets-law.html
+++ b/practice-areas/finance-services/capital-markets-law.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     We assist issuers with due diligence, prospectus preparation, and filings required by the Securities and Exchange Commission. For private placements, we structure transactions that qualify for exemptions while protecting investor interests.
-    </p>
-    <p>
-     Ongoing reporting obligations can be demanding. We advise on corporate governance, periodic disclosures, and compliance reviews to maintain credibility with regulators and the market.
-    </p>
-    <p>
-     Reach out to (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     to discuss capital market strategies tailored to your business goals.
-    </p>
+    <h2>Securities Offerings</h2>
+    <h3>Raising capital through public and private sales</h3>
+    <p>Our firm guides Alabama companies in drafting prospectuses and preparing filings with the Securities and Exchange Commission.</p>
+    <p>Gabriel Smith works with issuers to structure private placements that protect investor interests and comply with exemptions.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Ongoing Reporting</h2>
+    <h3>Maintaining good standing with regulators</h3>
+    <p>Periodic disclosures and corporate governance practices are key to market credibility. We help clients meet these obligations on schedule.</p>
+    <p>From annual reports to shareholder communications, we ensure compliance that supports investor confidence.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Strategic Guidance</h2>
+    <h3>Tailoring capital strategies for growth</h3>
+    <p>We analyze financing options that align with business plans while mitigating risk.</p>
+    <p>Contact Gabriel Smith in Opelika at (334) 750-1729 or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> for advice on capital market transactions.</p>
    </div>
   </section>
   <section class="back-to-top-section">

--- a/practice-areas/finance-services/financial-services-regulation.html
+++ b/practice-areas/finance-services/financial-services-regulation.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     Our services include reviewing compliance programs, drafting internal policies, and advising on examinations by state and federal agencies. We focus on requirements such as anti-money laundering standards and consumer disclosure obligations.
-    </p>
-    <p>
-     When enforcement actions arise, we represent clients in responding to subpoenas, negotiating settlements, and contesting penalties. Timely, informed advocacy helps reduce regulatory risk.
-    </p>
-    <p>
-     Contact us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     for assistance with the ever-changing landscape of financial regulation.
-    </p>
+    <h2>Compliance Programs</h2>
+    <h3>Building a culture of adherence</h3>
+    <p>We review internal policies and training to help financial institutions meet anti-money laundering and consumer disclosure obligations.</p>
+    <p>Gabriel Smith advises banks and lenders on examinations by state and federal agencies so that operations remain uninterrupted.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Enforcement Defense</h2>
+    <h3>Responding to investigations</h3>
+    <p>When regulators issue subpoenas or notices, prompt action is vital. We negotiate settlements and contest penalties when necessary.</p>
+    <p>Our goal is to minimize risk and keep your business moving forward.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Guidance for Alabama Institutions</h2>
+    <h3>Local insight for complex rules</h3>
+    <p>Financial services providers across Alabama rely on our understanding of both state and federal requirements.</p>
+    <p>For advice contact Gabriel Smith in Opelika at (334) 750-1729 or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.</p>
    </div>
   </section>
   <section class="back-to-top-section">

--- a/practice-areas/technology-data-privacy/cybersecurity-data-privacy-law.html
+++ b/practice-areas/technology-data-privacy/cybersecurity-data-privacy-law.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     We help businesses comply with state and federal laws, draft incident response plans, and review vendor contracts for security obligations. Proactive measures reduce exposure to breaches.
-    </p>
-    <p>
-     When a data incident occurs, we coordinate investigations, notifications, and cooperation with law enforcement. Our goal is to mitigate harm and maintain trust.
-    </p>
-    <p>
-     For help addressing cybersecurity and data privacy concerns, contact us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
+    <h2>Data Protection Planning</h2>
+    <h3>Reducing the risk of breaches</h3>
+    <p>We design policies and incident response plans that align with state and federal requirements.</p>
+    <p>Gabriel Smith reviews vendor agreements to ensure that security obligations are clearly defined.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Incident Response</h2>
+    <h3>Managing emergencies with care</h3>
+    <p>When a cyber event occurs we coordinate investigations, notifications and cooperation with law enforcement.</p>
+    <p>Our goal is to minimize damage and maintain trust with customers and regulators.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Ongoing Privacy Advice</h2>
+    <h3>Staying compliant in Alabama</h3>
+    <p>Businesses depend on up to date counsel as privacy laws continue to evolve.</p>
+    <p>For guidance contact Gabriel Smith at (334) 750-1729 or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.</p>
    </div>
   </section>
   <section class="back-to-top-section">

--- a/practice-areas/technology-data-privacy/internet-ecommerce-law.html
+++ b/practice-areas/technology-data-privacy/internet-ecommerce-law.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     We craft user agreements and privacy policies that address data security and consumer rights. Guidance on digital marketing and online advertising helps clients reach audiences while respecting regulatory boundaries.
-    </p>
-    <p>
-     When disputes arise over transactions or intellectual property, swift resolution is key. We handle domain name issues, online defamation, and contract claims arising from digital commerce.
-    </p>
-    <p>
-     For counsel on your internet ventures, call (334) 750-1729 or send an email to
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
+    <h2>Website Policies</h2>
+    <h3>Building trust with your users</h3>
+    <p>We craft clear terms of service and privacy notices that address data protection and consumer rights.</p>
+    <p>Gabriel Smith reviews marketing plans so that online advertising complies with state and federal guidelines.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Digital Transactions</h2>
+    <h3>Handling sales and disputes online</h3>
+    <p>From domain name issues to contract claims, we help resolve conflicts that emerge in the e-commerce space.</p>
+    <p>Our advice keeps your business moving while protecting intellectual property rights.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Support for Online Ventures</h2>
+    <h3>Your Opelika resource for internet law</h3>
+    <p>Whether you run a small shop or a growing marketplace, local counsel can guide you through regulatory challenges.</p>
+    <p>Contact us at (334) 750-1729 or <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> for tailored assistance.</p>
    </div>
   </section>
   <section class="back-to-top-section">

--- a/practice-areas/technology-data-privacy/technology-law.html
+++ b/practice-areas/technology-data-privacy/technology-law.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     We draft and negotiate software licenses, development agreements, and technology transfer contracts. Careful attention to ownership and usage rights helps clients avoid future disputes.
-    </p>
-    <p>
-     Emerging technologies often raise novel legal questions. We monitor legislative developments and counsel clients on compliance so that innovation can proceed without unnecessary delay.
-    </p>
-    <p>
-     Discuss your technology projects with us by calling (334) 750-1729 or emailing
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
-    </p>
+    <h2>Software Agreements</h2>
+    <h3>Protecting your intellectual property</h3>
+    <p>We prepare licensing and development contracts that spell out ownership and usage rights with precision.</p>
+    <p>Gabriel Smith helps clients avoid disputes by ensuring each agreement reflects the parties' expectations.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Intellectual Property</h2>
+    <h3>Securing and commercializing innovation</h3>
+    <p>Proper protection of software and technology assets is vital for growth. We advise on copyright, trademark and trade secret issues.</p>
+    <p>Our guidance allows businesses to bring new products to market while minimizing legal risk.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Advising Alabama Startups</h2>
+    <h3>Local counsel with a focus on innovation</h3>
+    <p>We monitor legislative changes and emerging trends so that new ventures stay compliant from day one.</p>
+    <p>Call (334) 750-1729 or email <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a> to discuss your technology plans in Opelika and beyond.</p>
    </div>
   </section>
   <section class="back-to-top-section">

--- a/practice-areas/technology-data-privacy/telecommunications-law.html
+++ b/practice-areas/technology-data-privacy/telecommunications-law.html
@@ -105,21 +105,28 @@
     </p>
    </div>
   </section>
-  <section class="alt">
+  <section class="section-light">
    <div class="container">
-    <p>
-     We advise carriers and infrastructure companies on Federal Communications Commission filings, compliance audits, and regulatory fees. Thorough preparation keeps projects on schedule.
-    </p>
-    <p>
-     As the industry evolves, questions arise about spectrum use, interconnection, and emerging technologies. We help clients address these issues and adapt to policy changes.
-    </p>
-    <p>
-     Reach us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     for guidance on telecommunications law matters.
-    </p>
+    <h2>Licensing and Compliance</h2>
+    <h3>Meeting federal and state requirements</h3>
+    <p>We assist carriers with Federal Communications Commission filings and regulatory fees to keep projects on schedule.</p>
+    <p>Gabriel Smith advises on audits and compliance reviews so that networks operate within the law.</p>
+   </div>
+  </section>
+  <section class="section-alt">
+   <div class="container">
+    <h2>Infrastructure Projects</h2>
+    <h3>Building reliable communications</h3>
+    <p>Issues such as spectrum use and interconnection demand careful attention. We provide guidance on contracts and permits for new construction.</p>
+    <p>Our approach helps clients manage risks and adapt to policy changes.</p>
+   </div>
+  </section>
+  <section class="section-light">
+   <div class="container">
+    <h2>Assistance in Opelika</h2>
+    <h3>Local knowledge for telecom providers</h3>
+    <p>As an Alabama attorney, Gabriel Smith offers insight into state regulations affecting telecommunications businesses.</p>
+    <p>For help call (334) 750-1729 or email <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.</p>
    </div>
   </section>
   <section class="back-to-top-section">


### PR DESCRIPTION
## Summary
- enhance finance practice area pages with three new sections each
- update technology and privacy pages with structured SEO content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d758bd288321bf2b4edba5b9dd87