### PR TITLE
Add detailed subsections for transportation and sports pages

### DIFF
--- a/practice-areas/sports-entertainment/entertainment-sports-law.html
+++ b/practice-areas/sports-entertainment/entertainment-sports-law.html
@@ -107,18 +107,43 @@
   </section>
   <section class="alt">
    <div class="container">
+    <h2>
+     Contract Development
+    </h2>
+    <h3>
+     Protecting Creative Work
+    </h3>
     <p>
-     From recording deals to endorsement arrangements, we draft and negotiate agreements that preserve your rights and ensure fair compensation. We also address licensing of music, film, and merchandising assets.
+     Entertainment and sports projects rely on carefully drafted agreements. We handle recording contracts, appearance releases, and licensing terms to safeguard your ownership rights and income.
     </p>
     <p>
-     When disputes arise over royalties, performance agreements, or sponsorship contracts, we aim to resolve conflicts efficiently through negotiation or litigation. Our understanding of industry customs guides each strategy.
+     Gabriel Smith negotiates with producers, sponsors, and distributors so that clients secure fair deals while maintaining control over their brands.
+    </p>
+    <h2>
+     Intellectual Property Issues
+    </h2>
+    <h3>
+     Trademarks and Copyright
+    </h3>
+    <p>
+     Athletes and entertainers build value through names, logos, and original works. We help register trademarks and protect copyrights against unauthorized use both online and in traditional media.
     </p>
     <p>
-     Located in Opelika, Alabama, the Law Office of Gabriel Smith LLC is ready to represent entertainers and athletes throughout the region. Contact us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     for assistance.
+     Proper registration and enforcement preserve revenue streams and prevent others from profiting from your identity or creations.
+    </p>
+    <h2>
+     Resolving Industry Disputes
+    </h2>
+    <h3>
+     Negotiation and Litigation
+    </h3>
+    <p>
+     Conflicts over royalties or sponsorship contracts can stall a career. We pursue practical solutions through mediation or, if needed, court proceedings to protect your reputation and earnings.
+    </p>
+    <p>
+     Reach the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     for representation in entertainment and sports matters.
     </p>
    </div>
   </section>

--- a/practice-areas/sports-entertainment/gaming-law.html
+++ b/practice-areas/sports-entertainment/gaming-law.html
@@ -107,18 +107,43 @@
   </section>
   <section class="alt">
    <div class="container">
+    <h2>
+     Licensing and Compliance
+    </h2>
+    <h3>
+     Meeting Regulatory Standards
+    </h3>
     <p>
-     Our guidance covers regulatory approvals, background investigations, and transactional agreements vital to launching or expanding a gaming enterprise. We also help businesses maintain ongoing compliance through regular audits and policy reviews.
+     Casinos, lotteries, and online platforms must secure proper licenses and follow strict reporting rules. Gabriel Smith assists with applications, background checks, and ongoing compliance to keep operations lawful.
     </p>
     <p>
-     Disputes can arise over licensing, revenue sharing, or patron issues. We assist in resolving these matters efficiently, whether through administrative hearings or litigation, always mindful of the highly regulated environment.
+     We coordinate with state agencies and advise on internal controls so that gaming establishments meet every requirement before opening their doors.
+    </p>
+    <h2>
+     Operational Guidance
+    </h2>
+    <h3>
+     Contracts and Security
+    </h3>
+    <p>
+     Successful gaming enterprises depend on clear agreements with vendors, landlords, and employees. Our firm drafts contracts that address revenue sharing and data security to protect your business interests.
     </p>
     <p>
-     For tailored advice on gaming ventures, reach the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
+     Regular policy reviews help maintain good standing with regulators and build trust with patrons.
+    </p>
+    <h2>
+     Resolving Gaming Disputes
+    </h2>
+    <h3>
+     Administrative and Court Actions
+    </h3>
+    <p>
+     When conflicts arise over licenses, revenue distribution, or patron complaints, prompt action is key. We represent clients before regulatory boards and in court to resolve issues efficiently.
+    </p>
+    <p>
+     Contact the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     for guidance on any gaming matter.
     </p>
    </div>
   </section>

--- a/practice-areas/sports-entertainment/sports-law.html
+++ b/practice-areas/sports-entertainment/sports-law.html
@@ -107,18 +107,42 @@
   </section>
   <section class="alt">
    <div class="container">
+    <h2>
+     Player Representation
+    </h2>
+    <h3>
+     Contracts and Endorsements
+    </h3>
     <p>
-     Negotiating a player agreement or endorsement deal requires an understanding of industry standards and league policies. We craft contracts that protect your interests while complying with NCAA or professional requirements.
+     Securing a strong playing contract or sponsorship deal requires careful negotiation. Gabriel Smith crafts agreements that comply with league rules while maximizing benefits for athletes and teams.
     </p>
     <p>
-     Disputes over eligibility, doping allegations, or disciplinary actions can threaten a career. Our firm provides skilled representation in hearings and arbitration proceedings to safeguard your reputation and opportunities.
+     We review compensation terms, incentives, and image rights so that clients understand every obligation before signing.
+    </p>
+    <h2>
+     Compliance and Governance
+    </h2>
+    <h3>
+     League and Association Rules
+    </h3>
+    <p>
+     Athletic organizations must observe regulations from governing bodies such as the NCAA and professional leagues. Our firm guides managers and players through eligibility requirements and disciplinary procedures.
     </p>
     <p>
-     The Law Office of Gabriel Smith LLC serves clients across Alabama from our Opelika office. For advice on sports-related matters, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
+     By monitoring rule changes and filing necessary paperwork, we help keep your career or program in good standing.
+    </p>
+    <h2>
+     Resolving Disputes
+    </h2>
+    <h3>
+     Arbitration and Litigation
+    </h3>
+    <p>
+     When conflicts arise over contracts or disciplinary actions, swift resolution preserves reputations and seasons. We advocate for clients before league panels and in court when needed.
+    </p>
+    <p>
+     For assistance with sports law matters in Alabama, call the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
     </p>
    </div>
   </section>

--- a/practice-areas/transportation-maritime/admiralty-maritime-law.html
+++ b/practice-areas/transportation-maritime/admiralty-maritime-law.html
@@ -107,18 +107,42 @@
   </section>
   <section class="alt">
    <div class="container">
+    <h2>
+     Maritime Compliance
+    </h2>
+    <h3>
+     Federal and International Rules
+    </h3>
     <p>
-     Admiralty law blends federal statutes with traditional maritime principles. We counsel ship owners, operators, and maritime workers on issues such as marine insurance, charter agreements, and liability for personal injuries at sea.
+     Admiralty law combines federal statutes with long standing maritime customs. Understanding these authorities keeps vessels and crews operating within the law and helps avoid costly disputes.
     </p>
     <p>
-     Whether a claim involves a commercial shipping line or a recreational boat, we analyze jurisdiction and applicable treaties to safeguard your rights. Our guidance helps clients navigate vessel arrests, limitation actions, and environmental regulations.
+     We guide ship owners and operators on documentation requirements, pollution prevention, and safety obligations so that voyages proceed smoothly from port to port.
+    </p>
+    <h2>
+     Resolving Maritime Disputes
+    </h2>
+    <h3>
+     Claims and Investigations
+    </h3>
+    <p>
+     When collisions or cargo damage occur, quick action preserves evidence and clarifies liability. Our firm coordinates with investigators and insurers to protect your interests under admiralty procedures.
     </p>
     <p>
-     Based in Opelika, Alabama, the Law Office of Gabriel Smith LLC offers prompt assistance throughout the Gulf Coast region. For counsel on maritime matters, call (334) 750-1729 or email
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
+     Whether a matter involves commercial shipping or recreational boating, we evaluate contracts and applicable treaties to seek fair outcomes through negotiation or litigation.
+    </p>
+    <h2>
+     Serving the Gulf Coast
+    </h2>
+    <h3>
+     Local Counsel in Alabama
+    </h3>
+    <p>
+     Based in Opelika, Gabriel Smith represents clients across the Gulf Coast. We handle marine insurance questions, charter agreements, and injury claims with attention to detail.
+    </p>
+    <p>
+     For guidance on admiralty and maritime issues, contact the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
     </p>
    </div>
   </section>

--- a/practice-areas/transportation-maritime/aviation-law.html
+++ b/practice-areas/transportation-maritime/aviation-law.html
@@ -107,18 +107,43 @@
   </section>
   <section class="alt">
    <div class="container">
+    <h2>
+     Aviation Compliance
+    </h2>
+    <h3>
+     Federal Guidelines
+    </h3>
     <p>
-     We represent pilots, maintenance providers, and passengers in matters involving the Federal Aviation Administration and state authorities. From licensing issues to accident investigations, we ensure your interests are protected.
+     The Federal Aviation Administration regulates pilot licensing, aircraft maintenance, and operational standards. Staying current with these requirements keeps flights legal and safe for passengers and crew.
     </p>
     <p>
-     Aircraft purchases and leasing arrangements demand careful documentation. We prepare and review contracts to safeguard your investment and to facilitate smooth transactions across domestic and international borders.
+     Gabriel Smith advises on inspections, record keeping, and reporting obligations so that businesses and individuals meet every mandate before taking off.
+    </p>
+    <h2>
+     Handling Aircraft Transactions
+    </h2>
+    <h3>
+     Purchases and Leases
+    </h3>
+    <p>
+     Buying or leasing an aircraft calls for precise contracts and thorough due diligence. We prepare documents that outline responsibilities, warranties, and financing terms to secure your investment.
     </p>
     <p>
-     If you face an aviation dispute or need guidance on compliance, the Law Office of Gabriel Smith LLC in Opelika stands ready to help. Reach us at (334) 750-1729 or
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
+     Our firm coordinates with lenders, insurers, and foreign registries to ensure each transaction complies with applicable laws across jurisdictions.
+    </p>
+    <h2>
+     Resolving Aviation Disputes
+    </h2>
+    <h3>
+     Claims and Investigations
+    </h3>
+    <p>
+     When incidents occur in the air or on the ground, swift investigation helps determine liability. We work with experts to review maintenance records and flight data to protect your legal rights.
+    </p>
+    <p>
+     Contact the Law Office of Gabriel Smith LLC in Opelika at (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>
+     for assistance with any aviation matter.
     </p>
    </div>
   </section>

--- a/practice-areas/transportation-maritime/railroad-transportation-law.html
+++ b/practice-areas/transportation-maritime/railroad-transportation-law.html
@@ -107,18 +107,42 @@
   </section>
   <section class="alt">
    <div class="container">
+    <h2>
+     Rail Industry Compliance
+    </h2>
+    <h3>
+     Federal Oversight
+    </h3>
     <p>
-     We advise clients on regulatory compliance with the Surface Transportation Board and Federal Railroad Administration. Whether negotiating track agreements or addressing hazardous materials rules, we strive to protect your business interests.
+     The Surface Transportation Board and Federal Railroad Administration regulate freight rates, track standards, and safety requirements. We help carriers and shippers understand these rules to keep operations running smoothly.
     </p>
     <p>
-     When accidents or property disputes arise, prompt investigation and knowledge of liability statutes are vital. We assist injured workers, landowners, and shippers in pursuing claims and resolving conflicts efficiently.
+     Gabriel Smith works closely with businesses to secure permits, negotiate trackage rights, and address hazardous materials regulations that apply throughout Alabama.
+    </p>
+    <h2>
+     Addressing Rail Accidents
+    </h2>
+    <h3>
+     Investigations and Claims
+    </h3>
+    <p>
+     When a collision or derailment occurs, immediate investigation preserves evidence and clarifies fault. Our firm coordinates with experts to evaluate equipment failures and compliance issues.
     </p>
     <p>
-     Clients throughout Alabama can rely on the Law Office of Gabriel Smith LLC for guidance on rail and transportation matters. Contact us at (334) 750-1729 or via email at
-     <a href="mailto:gabrieljoseph.smith@gmail.com">
-      gabrieljoseph.smith@gmail.com
-     </a>
-     .
+     We assist injured workers, landowners, and passengers with the claims process while navigating federal statutes and state laws that determine liability.
+    </p>
+    <h2>
+     Transportation Contracts
+    </h2>
+    <h3>
+     Freight and Property Matters
+    </h3>
+    <p>
+     Clear agreements are vital when moving goods by rail. We draft and review shipping contracts, easements, and real estate documents to protect our clients' interests across the network.
+    </p>
+    <p>
+     For assistance with any rail transportation issue, contact the Law Office of Gabriel Smith LLC at (334) 750-1729 or email
+     <a href="mailto:gabrieljoseph.smith@gmail.com">gabrieljoseph.smith@gmail.com</a>.
     </p>
    </div>
   </section>


### PR DESCRIPTION
## Summary
- expand maritime, aviation, and railroad law pages with new compliance and dispute-resolution sections
- add contract, intellectual property, and dispute sections for entertainment and sports pages
- enhance gaming law page with licensing, operations, and disputes guidance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d775f30c8321b7d1d49c92c3eb44