### PR TITLE
Add footer tagline to practice area pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -556,3 +556,15 @@ hr {
   margin: 0.25rem 0 0.75rem 1.25rem;
 }
 
+
+/* Footer Callout */
+.footer-callout {
+  background-color: var(--color-light2);
+  color: var(--color-dark1);
+  text-align: center;
+  padding: 2rem 0;
+}
+.footer-callout h1 {
+  font-family: var(--font-heading);
+  margin-bottom: 0.5rem;
+}

--- a/practice-areas/civil-litigation/appellate-law.html
+++ b/practice-areas/civil-litigation/appellate-law.html
@@ -153,6 +153,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/civil-litigation/civil-litigation.html
+++ b/practice-areas/civil-litigation/civil-litigation.html
@@ -153,6 +153,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/civil-litigation/class-actions.html
+++ b/practice-areas/civil-litigation/class-actions.html
@@ -153,6 +153,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/civil-litigation/mass-tort-law.html
+++ b/practice-areas/civil-litigation/mass-tort-law.html
@@ -153,6 +153,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/criminal-law/criminal-defense.html
+++ b/practice-areas/criminal-law/criminal-defense.html
@@ -161,6 +161,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/criminal-law/hate-crime-law.html
+++ b/practice-areas/criminal-law/hate-crime-law.html
@@ -153,6 +153,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/criminal-law/juvenile-law.html
+++ b/practice-areas/criminal-law/juvenile-law.html
@@ -153,6 +153,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/criminal-law/white-collar-criminal-defense.html
+++ b/practice-areas/criminal-law/white-collar-criminal-defense.html
@@ -153,6 +153,16 @@
     </p>
    </div>
   </section>
+  <section class="footer-callout">
+   <div class="container">
+    <h1>
+     Gabriel Smith Alabama Attorney
+    </h1>
+    <p>
+     Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.
+    </p>
+   </div>
+  </section>
   <footer class="footer">
    <div class="container">
     <p>


### PR DESCRIPTION
## Summary
- style footer callout section
- add tagline section before the footer on criminal law pages
- add tagline section before the footer on civil litigation pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68751c5aaff083218d6deec6cb7a95d9