### PR TITLE
Fix practice area styles and add tagline

### DIFF
--- a/practice-areas/healthcare-life-sciences/biotechnology-life-sciences-law.html
+++ b/practice-areas/healthcare-life-sciences/biotechnology-life-sciences-law.html
@@ -173,8 +173,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/healthcare-life-sciences/healthcare-law.html
+++ b/practice-areas/healthcare-life-sciences/healthcare-law.html
@@ -173,8 +173,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/healthcare-life-sciences/medical-malpractice-law.html
+++ b/practice-areas/healthcare-life-sciences/medical-malpractice-law.html
@@ -173,8 +173,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/healthcare-life-sciences/pharmaceutical-medical-device-law.html
+++ b/practice-areas/healthcare-life-sciences/pharmaceutical-medical-device-law.html
@@ -173,8 +173,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/discrimination-law.html
+++ b/practice-areas/labor-employment/discrimination-law.html
@@ -26,6 +26,7 @@
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -160,8 +161,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/erisa-employee-benefits-law.html
+++ b/practice-areas/labor-employment/erisa-employee-benefits-law.html
@@ -26,6 +26,7 @@
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -160,8 +161,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/labor-employment-law.html
+++ b/practice-areas/labor-employment/labor-employment-law.html
@@ -26,6 +26,7 @@
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -160,8 +161,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>

--- a/practice-areas/labor-employment/workers-compensation-law.html
+++ b/practice-areas/labor-employment/workers-compensation-law.html
@@ -26,6 +26,7 @@
   <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
   <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&amp;family=Open+Sans:wght@400;600&amp;display=swap" rel="stylesheet"/>
   <link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-yH+xTq5Vf3L7hIwrKyYVJZZzKzbwQ6VykBLL8GMDJ9ZhDJW60F7uO3cu6UytzszbmWzxubUAN4+Y3qFjqZ4gJw==" referrerpolicy="no-referrer" rel="stylesheet"/>
+  <link href="../../css/style.css" rel="stylesheet"/>
  </head>
  <body>
   <a class="skip-link" href="#main-content">
@@ -160,8 +161,14 @@
       </a>
      </p>
     </div>
-   </section>
-  </main>
+  </section>
+  <section class="section-light text-center">
+   <div class="container">
+    <h1>Gabriel Smith Alabama Attorney</h1>
+    <p>Providing results-driven personal injury, criminal defense, civil litigation, and estate planning services across Alabama.</p>
+   </div>
+  </section>
+ </main>
   <footer class="footer">
    <div class="container">
     <p>


### PR DESCRIPTION
## Summary
- link style.css in labor employment practice pages
- add tagline before footer on labor and healthcare practice pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68751c81d78083219538d642e325d22c